### PR TITLE
Fix direction indexing

### DIFF
--- a/js/js.js
+++ b/js/js.js
@@ -357,7 +357,8 @@ function updateGPSInfo() {
                 "Зх",
                 "ПнЗх",
             ];
-            const directionIndex = Math.round(currentGPSData.heading / 45) % 8;
+            const directionIndex =
+                Math.round(currentGPSData.heading / 45) % directions.length;
             headingInfoEl.textContent = `${currentGPSData.heading.toFixed(
                 0
             )}° (${directions[directionIndex]})`;


### PR DESCRIPTION
## Summary
- fix heading compass directions to use array length for modulo

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684096bebe508329a27ad6286f1a1f94