### PR TITLE
Improve service worker caching

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,15 +1,46 @@
-// Кешує всі ресурси тому викликає помилку переповнення кешу
-// self.addEventListener("install", (event) => event.waitUntil(caches.open("v1").then((cache) => cache.addAll(["/"]))));
+const CACHE_NAME = 'v2';
+const urlsToCache = [
+  '/',
+  '/index.html',
+  '/styles/style.css',
+  '/js/js.js',
+  '/js/registration_service_worker.js',
+  '/icon/icon.png',
+  '/icon/icon_144.png',
+  '/icon/icon_192.png',
+  '/icon/icon_512.png',
+  '/pwa.webmanifest'
+];
 
-// Кешує тільки визначені ресурси
-self.addEventListener("install", (event) => event.waitUntil(caches.open("v1").then((cache) => cache.addAll(["/index.html"]))));
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
+  );
+});
 
-addEventListener("fetch", function (event) {
-    if (event.request.headers.get("Accept").includes("text/html")) {
-        event.respondWith(
-            fetch(event.request)
-                .then((response) => response)
-                .catch((error) => caches.match("index.html"))
-        );
-    }
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.headers.get('Accept')?.includes('text/html')) {
+    event.respondWith(
+      fetch(event.request)
+        .then(response => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          return response;
+        })
+        .catch(() => caches.match(event.request).then(res => res || caches.match('/index.html')))
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
 });


### PR DESCRIPTION
## Summary
- cache additional assets for offline support
- clean old caches and use versioned cache `v2`
- implement cache-first strategy with network fallback

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68409914d4c08329968c3057d449c652