### PR TITLE
Fix data table overflow on mobile

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -320,6 +320,7 @@ h1 {
   padding: 15px;
   max-height: 200px;
   overflow-y: auto;
+  overflow-x: auto;
   font-family: "Courier New", monospace;
   font-size: 0.85em;
 }
@@ -327,6 +328,7 @@ h1 {
 .data-row {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+  min-width: 620px;
   gap: 10px;
   padding: 8px 0;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
@@ -498,13 +500,11 @@ h1 {
   }
 
   .data-row {
-    grid-template-columns: repeat(3, 1fr);
     gap: 5px;
     font-size: 0.7em;
   }
 
   .data-header-row {
-    grid-template-columns: repeat(3, 1fr);
     padding: 8px;
   }
 


### PR DESCRIPTION
## Summary
- keep 7-column layout for `.data-row`
- let `.data-table` scroll horizontally
- prevent column wrapping on mobile by removing 3-column overrides
- set a min-width so the table maintains alignment

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68412202f3e0832990c0d45b51472e1d