### PR TITLE
Add defer to Chart.js script

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 
     <script defer src="js/js.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   </head>
 
   <body data-theme="light">


### PR DESCRIPTION
## Summary
- defer Chart.js so loading waits until document is parsed

## Testing
- `curl -I https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js | head` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68412316216083298b4f67be532f5dcd