### PR TITLE
Handle reconnect automatically

### DIFF
--- a/js/js.js
+++ b/js/js.js
@@ -1007,7 +1007,7 @@ window.addEventListener("orientationchange", () => {
 
 // Відновлення тесту після втрати з'єднання
 window.addEventListener('online', () => {
-    if (testActive && !testInProgress) {
+    if (testActive) {
         isConnected = true;
         runTest();
     }


### PR DESCRIPTION
## Summary
- call `runTest()` on every online event while a test is active

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6845d81dd6548329bc937c4ee2ab8420