### PR TITLE
Fix service worker caching of connectivity checks

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -27,6 +27,15 @@ self.addEventListener('activate', event => {
 });
 
 self.addEventListener('fetch', event => {
+  const url = event.request.url;
+  if (
+    url.startsWith('https://speed.cloudflare.com/__down') ||
+    url.startsWith('https://www.google.com/generate_204')
+  ) {
+    // Bypass the service worker for connectivity check requests so that
+    // they are never cached and always hit the network.
+    return;
+  }
   if (event.request.headers.get('Accept')?.includes('text/html')) {
     event.respondWith(
       fetch(event.request)


### PR DESCRIPTION
## Summary
- prevent service worker from caching network check URLs so reconnect detection works

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845ddc9d8c8832994a13fe95eabf599