### PR TITLE
Fix reconnect loop exit when test stopped

### DIFF
--- a/js/js.js
+++ b/js/js.js
@@ -780,6 +780,7 @@ async function runTest() {
       // Якщо isConnected === false, то засікаємо «retry until online»:
       if (!isConnected) {
         await waitForReconnect();
+        if (!testActive) break;
       }
 
       // Коли вже точно онлайн, пробуємо робити реальний fetch
@@ -852,6 +853,7 @@ async function runTest() {
       try { reader.cancel(); } catch (_) {}
       try { resp.body.cancel(); } catch (_) {}
       await waitForReconnect();
+      if (!testActive) break;
       // Після повернення з waitForReconnect, переходимо до нового кола зовнішнього while:
       continue;
     }


### PR DESCRIPTION
## Summary
- ensure `runTest` stops if user disables the test while waiting for reconnection

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845ed581de08329b790fcb52a77a063