### PR TITLE
Fix reconnection check

### DIFF
--- a/js/js.js
+++ b/js/js.js
@@ -883,16 +883,23 @@ async function waitForReconnect() {
   while (testActive && !isConnected) {
     try {
       addLog("Перевірка з'єднання…");
-      const resp1 = await fetchWithTimeout(checkUrl1, { cache: "no-store" }, 500);
-      if (resp1.ok) {
-        // Якщо принаймні одиничний байт вдалося завантажити — вважаємо, що ми вже онлайн
+      const resp1 = await fetchWithTimeout(
+        checkUrl1,
+        { cache: "no-store", mode: "no-cors" },
+        500
+      );
+      if (resp1) {
+        // Навіть без CORS, якщо запит завершився успішно — мережа присутня
         isConnected = true;
         break;
       }
 
-      const resp2 = await fetchWithTimeout(checkUrl2, { cache: "no-store" }, 500);
-      if (resp2.ok) {
-        // Якщо другий ресурс відповів позитивно — вважаємо, що мережа відновлена
+      const resp2 = await fetchWithTimeout(
+        checkUrl2,
+        { cache: "no-store", mode: "no-cors" },
+        500
+      );
+      if (resp2) {
         isConnected = true;
         break;
       }


### PR DESCRIPTION
## Summary
- handle CORS by using `mode: "no-cors"` when checking network
- treat any successful fetch as proof of connectivity

## Testing
- `node --check js/js.js`

------
https://chatgpt.com/codex/tasks/task_e_6845ee5e84d4832981cb8e93d98fc17a