### PR TITLE
Ensure connectivity checks bypass cache

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -32,8 +32,8 @@ self.addEventListener('fetch', event => {
     url.startsWith('https://speed.cloudflare.com/__down') ||
     url.startsWith('https://www.google.com/generate_204')
   ) {
-    // Bypass the service worker for connectivity check requests so that
-    // they are never cached and always hit the network.
+    // Always fetch connectivity check requests from the network without caching
+    event.respondWith(fetch(event.request, { cache: 'no-store' }));
     return;
   }
   if (event.request.headers.get('Accept')?.includes('text/html')) {


### PR DESCRIPTION
## Summary
- fetch connectivity-check URLs directly using `event.respondWith(fetch(...))`
- prevent caching by specifying `cache: 'no-store'`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846860a5284832991571dbe77146d1d