### PR TITLE
Increase timeout after reconnect

### DIFF
--- a/js/js.js
+++ b/js/js.js
@@ -833,7 +833,9 @@ async function runTest() {
       const resp = await fetchWithTimeout(
         `https://speed.cloudflare.com/__down?bytes=${TARGET}`,
         { cache: "no-store" },
-        10000
+        // Даємо більше часу на відповідь після втрати зв'язку,
+        // щоб тест не падав одразу на мережах з високою затримкою
+        30000
       );
 
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);


### PR DESCRIPTION
## Summary
- allow more time for the main download request

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684686de717883299b0ee932fa279a49