### PR TITLE
Fix service worker registration and cache paths

### DIFF
--- a/js/registration_service_worker.js
+++ b/js/registration_service_worker.js
@@ -8,13 +8,13 @@
 
 if ("serviceWorker" in navigator) {
     window.addEventListener("load", () => {
-        navigator.serviceWorker.register("/sw.js", { scope: "/" }).then((registration) => console.log(registration.scope), (err) => console.log(err));
+        navigator.serviceWorker.register("sw.js", { scope: "/" }).then((registration) => console.log(registration.scope), (err) => console.log(err));
     });
 }
 
 /* if ("serviceWorker" in navigator) {
     window.addEventListener("load", function () {
-        navigator.serviceWorker.register("/sw.js", { scope: "/" }).then(
+        navigator.serviceWorker.register("sw.js", { scope: "/" }).then(
             function (registration) {
                 // Registration was successful
                 // console.log('Реєстрація Service Worker пройшла успішно: ', registration.scope);

--- a/sw.js
+++ b/sw.js
@@ -1,15 +1,15 @@
 const CACHE_NAME = 'v2';
 const urlsToCache = [
-  '/',
-  '/index.html',
-  '/styles/style.css',
-  '/js/js.js',
-  '/js/registration_service_worker.js',
-  '/icon/icon.png',
-  '/icon/icon_144.png',
-  '/icon/icon_192.png',
-  '/icon/icon_512.png',
-  '/pwa.webmanifest'
+  '.',
+  'index.html',
+  'styles/style.css',
+  'js/js.js',
+  'js/registration_service_worker.js',
+  'icon/icon.png',
+  'icon/icon_144.png',
+  'icon/icon_192.png',
+  'icon/icon_512.png',
+  'pwa.webmanifest'
 ];
 
 self.addEventListener('install', event => {
@@ -40,7 +40,7 @@ self.addEventListener('fetch', event => {
           caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
           return response;
         })
-        .catch(() => caches.match(event.request).then(res => res || caches.match('/index.html')))
+        .catch(() => caches.match(event.request).then(res => res || caches.match('index.html')))
     );
     return;
   }


### PR DESCRIPTION
## Summary
- register service worker using relative path `sw.js`
- use relative paths in `urlsToCache`

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68473d789ef083299e133ae45e550698