### PR TITLE
Fix fullscreen layout and resize chart

### DIFF
--- a/js/js.js
+++ b/js/js.js
@@ -1089,12 +1089,22 @@ function toggleFullscreen() {
             document.documentElement.requestFullscreen();
         }
         showNotification("Повноекранний режим увімкнено");
+        setTimeout(() => {
+            if (speedChart) {
+                speedChart.resize();
+            }
+        }, ORIENTATION_DELAY);
     } else {
         body.classList.remove("fullscreen-mode");
         if (document.exitFullscreen) {
             document.exitFullscreen();
         }
         showNotification("Повноекранний режим вимкнено");
+        setTimeout(() => {
+            if (speedChart) {
+                speedChart.resize();
+            }
+        }, ORIENTATION_DELAY);
     }
 }
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -55,12 +55,15 @@ body {
 
 .fullscreen-mode .container {
   width: 100%;
-  height: 100%;
+  /* Allow container to grow beyond viewport height */
+  min-height: 100%;
+  max-height: none;
   max-width: none;
   border-radius: 0;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  overflow-y: auto;
 }
 
 .container {


### PR DESCRIPTION
## Summary
- let fullscreen container scroll vertically
- resize the chart after toggling fullscreen so it's always visible

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6847f8c0981c83298aa2bdb452841515