### PR TITLE
Update info block styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,43 +185,43 @@
       </div>
 
       <!-- Розширена GPS інформація -->
-      <div class="gps-info" id="gpsInfo">
+      <div class="info" id="gpsInfo">
         <div style="font-weight: bold; margin-bottom: 10px">
           Детальний GPS Статус
         </div>
-        <div class="gps-info-row">
+        <div class="info-row">
           <span>Статус GPS:</span>
           <span id="gpsStatus">Не активний</span>
         </div>
-        <div class="gps-info-row">
+        <div class="info-row">
           <span>Точність:</span>
           <span id="gpsAccuracy">N/A</span>
         </div>
-        <div class="gps-info-row">
+        <div class="info-row">
           <span>Поточні координати:</span>
           <span id="currentCoords">N/A</span>
         </div>
-        <div class="gps-info-row">
+        <div class="info-row">
           <span>Висота:</span>
           <span id="altitudeInfo">N/A</span>
         </div>
-        <div class="gps-info-row">
+        <div class="info-row">
           <span>GPS швидкість:</span>
           <span id="gpsSpeedInfo">N/A</span>
         </div>
-        <div class="gps-info-row">
+        <div class="info-row">
           <span>Напрямок:</span>
           <span id="headingInfo">N/A</span>
         </div>
-        <div class="gps-info-row">
+        <div class="info-row">
           <span>Відстань від попередньої точки:</span>
           <span id="distanceInfo">N/A</span>
         </div>
-        <div class="gps-info-row">
+        <div class="info-row">
           <span>Загальна відстань:</span>
           <span id="totalDistanceInfo">0.00 км</span>
         </div>
-        <div class="gps-info-row">
+        <div class="info-row">
           <span>Останнє збереження:</span>
           <span id="lastSaveInfo">Немає даних</span>
         </div>
@@ -260,15 +260,15 @@
       </div>
 
       <div class="info" id="info">
-        <div><strong>IP:</strong> <span id="ip">-</span></div>
-        <div><strong>Хост:</strong> <span id="hostname">-</span></div>
-        <div><strong>Місто:</strong> <span id="city">-</span></div>
-        <div><strong>Регіон:</strong> <span id="region">-</span></div>
-        <div><strong>Країна:</strong> <span id="country">-</span></div>
-        <div><strong>Координати:</strong> <span id="loc">-</span></div>
-        <div><strong>Провайдер:</strong> <span id="org">-</span></div>
-        <div><strong>Поштовий індекс:</strong> <span id="postal">-</span></div>
-        <div><strong>Часовий пояс:</strong> <span id="timezone">-</span></div>
+        <div class="info-row"><span>IP:</span><span id="ip">-</span></div>
+        <div class="info-row"><span>Хост:</span><span id="hostname">-</span></div>
+        <div class="info-row"><span>Місто:</span><span id="city">-</span></div>
+        <div class="info-row"><span>Регіон:</span><span id="region">-</span></div>
+        <div class="info-row"><span>Країна:</span><span id="country">-</span></div>
+        <div class="info-row"><span>Координати:</span><span id="loc">-</span></div>
+        <div class="info-row"><span>Провайдер:</span><span id="org">-</span></div>
+        <div class="info-row"><span>Поштовий індекс:</span><span id="postal">-</span></div>
+        <div class="info-row"><span>Часовий пояс:</span><span id="timezone">-</span></div>
       </div>
     </div>
   </body>

--- a/styles/style.css
+++ b/styles/style.css
@@ -188,19 +188,38 @@ h1 {
   opacity: 0.9;
 }
 
-.gps-info {
+.info {
   background: var(--glass-bg);
   border-radius: 10px;
   padding: 5px;
   margin: 5px 0;
   font-size: 0.9em;
   border: 1px solid var(--glass-border);
+  backdrop-filter: blur(10px);
 }
 
-.gps-info-row {
+.info-row {
   display: flex;
   justify-content: space-between;
   margin: 5px 0;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.info-row:last-child {
+  border-bottom: none;
+}
+
+.info-row span:first-child {
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+.info-row span:last-child {
+  text-align: right;
+  flex: 1;
+  opacity: 0.9;
+  word-break: break-word;
 }
 
 .settings-panel {
@@ -468,7 +487,7 @@ h1 {
     font-size: 1.1em;
   }
 
-  .gps-info {
+  .info {
     font-size: 0.8em;
     padding: 5px;
     margin: 5px 0;
@@ -538,36 +557,14 @@ h1 {
 }
 
 /* === Інформаційна панель IP / ISP ======================================= */
-#info {
+.info {
   background: var(--glass-bg);
   border: 1px solid var(--glass-border);
-  border-radius: 10px;   /* збігається з #gpsInfo */
+  border-radius: 10px;   /* збігається з gpsInfo */
   padding: 5px;          /* компактний відступ */
   margin: 5px 0;
   font-size: 0.9em;
   backdrop-filter: blur(10px);
-}
-
-/* кожен рядок усередині #info → одна лінійка «підпис-значення» */
-#info > div {
-  display: flex;
-  justify-content: space-between; /* підпис зліва, значення справа */
-  gap: 12px;
-  margin: 4px 0;
-}
-
-/* підпис (лівий бік) */
-#info strong {
-  font-weight: 600;
-  opacity: 0.85;
-}
-
-/* значення (правий бік) */
-#info span {
-  text-align: right;     /* вирівнюємо текст по правому краю */
-  flex: 1;               /* заповнює доступний простір, щоб підписи не «стриба́ли» */
-  opacity: 0.9;
-  word-break: break-word;
 }
 
 
@@ -582,8 +579,7 @@ h1 {
     row-gap: 10px;
   }
   
-  .info strong,
-  .info span {
+  .info-row span {
     display: inline;                     /* підпис і значення в один рядок */
   }
 }


### PR DESCRIPTION
## Summary
- use shared `info` class for GPS and IP blocks
- convert IP info markup to rows like GPS info
- add bottom separators for rows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684aab7f62d88329b012b0f63a479c89