### PR TITLE
Add site URL in manifest and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ A minimal browser-based speed test app.
 ## Usage
 
 Open `index.html` in your browser and the test will begin.
+Or visit [https://www.gonettest.com](https://www.gonettest.com) to use the hosted version.

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta id="themeColorMeta" name="theme-color" content="#667eea" />
     <title>Тест швидкості інтернету</title>
 
-    <link rel="canonical" href="https://1111.com/" />
+    <link rel="canonical" href="https://www.gonettest.com/" />
     <!-- Для iOS -->
     <meta name="apple-mobile-web-app-capable" content="yes">
     <!-- Для Android -->

--- a/js/registration_service_worker.js
+++ b/js/registration_service_worker.js
@@ -8,7 +8,7 @@
 
 if ("serviceWorker" in navigator) {
     window.addEventListener("load", () => {
-        navigator.serviceWorker.register("sw.js", { scope: "/gonettest/" }).then((registration) => console.log(registration.scope), (err) => console.log(err));
+        navigator.serviceWorker.register("sw.js", { scope: "/" }).then((registration) => console.log(registration.scope), (err) => console.log(err));
     });
 }
 

--- a/pwa.webmanifest
+++ b/pwa.webmanifest
@@ -22,8 +22,8 @@
             "purpose": "any maskable"
         }
     ],
-    "scope": "./",
-    "start_url": "./index.html",
+    "scope": "https://www.gonettest.com/",
+    "start_url": "https://www.gonettest.com/index.html",
     "display": "fullscreen",
     "theme_color": "#696969",
     "background_color": "#696969"


### PR DESCRIPTION
## Summary
- point canonical link to www.gonettest.com
- register service worker for root scope
- set PWA manifest start URL and scope to the site
- link to hosted site in README

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e6757a7ec8329914cb1e1ad3cb11e