### PR TITLE
Add CSS rule to limit operator display

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -188,6 +188,14 @@ h1 {
   opacity: 0.9;
 }
 
+/* Truncate operator text to at most 10 characters */
+#operator {
+  max-width: 10ch;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .info {
   background: var(--glass-bg);
   border-radius: 10px;


### PR DESCRIPTION
## Summary
- ensure that the `#operator` element displays no more than 10 characters by
  truncating with ellipsis

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e6dcb49a8832989a40af21eb24fae