### PR TITLE
Add service worker registration error notification

### DIFF
--- a/js/registration_service_worker.js
+++ b/js/registration_service_worker.js
@@ -8,7 +8,15 @@
 
 if ("serviceWorker" in navigator) {
     window.addEventListener("load", () => {
-        navigator.serviceWorker.register("./sw.js", { scope: "./" }).then((registration) => console.log(registration.scope), (err) => console.log(err));
+        navigator.serviceWorker
+            .register("./sw.js", { scope: "./" })
+            .then((registration) => console.log(registration.scope))
+            .catch((err) => {
+                console.error("Service worker registration failed:", err);
+                if (typeof showNotification === "function") {
+                    showNotification("Service worker error");
+                }
+            });
     });
 }
 


### PR DESCRIPTION
## Summary
- handle service worker registration errors by logging them and optionally showing a notification

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e79d67e0083298ac40c43ba18026f