### PR TITLE
Add preconnect links

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,11 @@
     />
     <link rel="manifest" href="pwa.webmanifest" />
 
+    <link rel="preconnect" href="https://ipinfo.io" crossorigin>
+    <link rel="preconnect" href="https://speed.cloudflare.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link rel="preconnect" href="https://tile.openstreetmap.org" crossorigin>
+
     <link href="styles/style.css" rel="stylesheet" type="text/css" />
     <link rel="preload" href="styles/leaflet.css" as="style" onload="this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="styles/leaflet.css"></noscript>


### PR DESCRIPTION
## Summary
- preconnect to ipinfo.io, speed.cloudflare.com, jsdelivr.net, and tile.openstreetmap.org

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e8296c53c8329a2b0da8e5bac9fb9