### PR TITLE
Add preload hint for Chart.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,10 @@
 
     <script defer src="js/leaflet.js"></script>
 
+    <link rel="preload"
+          href="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"
+          as="script">
+
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   </head>
 


### PR DESCRIPTION
## Summary
- hint the browser to preload Chart.js while keeping the defer script tag

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684e8308fb688329bdee21129a304e17