### PR TITLE
Update Leaflet placeholders

### DIFF
--- a/js/leaflet.js
+++ b/js/leaflet.js
@@ -1,1 +1,43 @@
-// Placeholder for leaflet.js version 1.9.4
+(function(global) {
+  // Minimal Leaflet stub - offline placeholder.
+  const L = {};
+
+  L.map = function(id) {
+    return {
+      _id: id,
+      _center: [0, 0],
+      _zoom: 0,
+      setView(center, zoom) {
+        this._center = center;
+        this._zoom = zoom;
+        return this;
+      },
+      addLayer(layer) {
+        if (layer && typeof layer.addTo === 'function') {
+          layer.addTo(this);
+        }
+        return this;
+      }
+    };
+  };
+
+  L.tileLayer = function(urlTemplate, options) {
+    return {
+      addTo(map) {
+        console.log('Stub tileLayer added to map', map);
+        return this;
+      }
+    };
+  };
+
+  L.circleMarker = function(latlng, options) {
+    return {
+      addTo(map) {
+        console.log('Stub circleMarker added to map', map);
+        return this;
+      }
+    };
+  };
+
+  global.L = L;
+})(this);

--- a/styles/leaflet.css
+++ b/styles/leaflet.css
@@ -1,1 +1,2 @@
-/* Placeholder for leaflet.css version 1.9.4 */
+/* Minimal Leaflet CSS placeholder for offline use */
+#map { height: 180px; }


### PR DESCRIPTION
## Summary
- replace placeholder JS with a minimal Leaflet stub
- add placeholder CSS for Leaflet

## Testing
- `node - <<'EOF'
const { L } = require('./js/leaflet.js');
function initMap(){
  let map = L.map('map').setView([48,31],6);
  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {}).addTo(map);
  console.log('initMap finished');
}
initMap();
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684e86abd800832981d555a77ef9d88e