### PR TITLE
Refactor mobile CSS overrides

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -490,12 +490,6 @@ h1 {
 
   .stats {
     grid-template-columns: repeat(2, 1fr);
-    gap: 5px;
-    margin: 5px 0;
-  }
-
-  .stat-item {
-    padding: 5px;
   }
 
   .stat-value {


### PR DESCRIPTION
## Summary
- deduplicate `.stat-item` rules
- override only changing properties for `.stats`, `.data-table` and `.data-row`

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_684ef97f0ea483299b89bdaf659eac9b