### PR TITLE
Add placeholder and error message classes

### DIFF
--- a/js/js.js
+++ b/js/js.js
@@ -153,7 +153,7 @@ async function detectISP() {
         }
     } catch (e) {
         document.getElementById('info').innerHTML =
-            '<div style="color:red;">Не вдалося отримати інформацію про з’єднання</div>';
+            '<div class="error-message">Не вдалося отримати інформацію про з’єднання</div>';
         addLog('detectISP error: ' + e.message);
     }
 }
@@ -687,7 +687,7 @@ function updateDataDisplay() {
 
     if (lastRecords.length === 0) {
         dataDisplay.innerHTML =
-            '<div style="text-align: center; padding: 20px; opacity: 0.6;">Немає даних</div>';
+            '<div class="placeholder">Немає даних</div>';
         return;
     }
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -609,3 +609,11 @@ h1 {
 .p-20 { padding: 20px; }
 .opacity-60 { opacity: 0.6; }
 .fw-bold { font-weight: bold; }
+.placeholder {
+  text-align: center;
+  padding: 20px;
+  opacity: 0.6;
+}
+.error-message {
+  color: var(--warning-color);
+}


### PR DESCRIPTION
## Summary
- add `.placeholder` and `.error-message` utility classes
- use new classes in JavaScript

## Testing
- `grep -n "style=\"" -n js/js.js`

------
https://chatgpt.com/codex/tasks/task_e_684efa6315d48329bc8cf2b055ec58be