### PR TITLE
Fix logo oversize in mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 
     <div class="container">
 
-      <img src="icon/icon.png" alt="Логотип" class="logo" width="483" height="483" />
+      <img src="icon/icon.png" alt="Логотип" class="logo" width="50" height="50" />
       
       <div class="theme-controls">
         <button


### PR DESCRIPTION
## Summary
- match the logo `width` and `height` attributes to the CSS size

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_684fd574a1888329a2921f0a0c868b2a