### PR TITLE
Fix mobile layout overflow

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -25,8 +25,11 @@
   padding: 0;
   box-sizing: border-box;
 }
-html, body {
+html,
+body {
   overscroll-behavior-y: none;
+  max-width: 100vw;
+  overflow-x: hidden;
 }
 body {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
@@ -46,7 +49,7 @@ body {
   position: fixed;
   top: 0;
   left: 0;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   z-index: 9999;
   padding: 0;
@@ -139,6 +142,19 @@ h1 {
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 5px;
   margin: 5px 0;
+}
+
+/* Prevent grid elements from expanding the container */
+.main-grid,
+.stats,
+.data-row {
+  min-width: 0;
+}
+
+.stats > .stat-item,
+.data-row > div {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .stat-item {
@@ -453,8 +469,8 @@ h1 {
 
   .container {
     padding: 5px;
-    width: 100%;
-    max-width: 100%;
+    width: calc(100% - 20px); /* account for body padding */
+    max-width: calc(100% - 20px);
     margin: 0;
     border-radius: 15px;
     min-height: calc(100vh - 20px);


### PR DESCRIPTION
## Summary
- limit `<html>` and `<body>` width to viewport
- avoid extra width when entering fullscreen
- prevent grid cells from forcing container width
- shrink container width on small screens

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd7ebea648329b5396411235d9109