### PR TITLE
Fix table overflow on mobile

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -584,8 +584,7 @@ h1 {
   .data-row {
     gap: 5px;
     font-size: 0.7em;
-    min-width: 500px;
-    grid-template-columns: repeat(7, minmax(60px, 1fr));
+    grid-template-columns: repeat(7, 1fr);
   }
 
   .data-header-row {


### PR DESCRIPTION
## Summary
- remove minimum width from data table rows on mobile layout
- allow grid columns to shrink evenly

## Testing
- `grep -n "min-width" -n styles/style.css`


------
https://chatgpt.com/codex/tasks/task_e_684feda6cb2083298de019524e4aa9ff