### PR TITLE
Set dark theme as default

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Streaming data download speed test on the way">
-    <meta id="themeColorMeta" name="theme-color" content="#667eea" />
+    <meta id="themeColorMeta" name="theme-color" content="#1a1a2e" />
     <title>Тест швидкості інтернету</title>
 
     <link rel="canonical" href="https://www.gonettest.com/" />
@@ -44,7 +44,7 @@
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   </head>
 
-<body data-theme="light">
+<body data-theme="dark">
     
     <div class="alert-indicator" id="alertIndicator">Втрачено з'єднання!</div>
 

--- a/pwa.webmanifest
+++ b/pwa.webmanifest
@@ -25,6 +25,6 @@
     "scope": "./",
     "start_url": "./index.html",
     "display": "fullscreen",
-    "theme_color": "#696969",
-    "background_color": "#696969"
+    "theme_color": "#1a1a2e",
+    "background_color": "#1a1a2e"
 }


### PR DESCRIPTION
## Summary
- default to dark theme for initial page load
- adjust manifest theme color for dark appearance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851dc2a5a588329ad32899a6bf2aeca