### PR TITLE
Implement theme persistence and fullscreen scrolling

### DIFF
--- a/js/js.js
+++ b/js/js.js
@@ -1320,6 +1320,7 @@ function toggleTheme() {
     const currentTheme = body.getAttribute("data-theme");
     const newTheme = currentTheme === "dark" ? "light" : "dark";
     body.setAttribute("data-theme", newTheme);
+    localStorage.setItem('theme', newTheme);
 
     // Update theme color meta tag
     const themeColorMeta = document.getElementById('themeColorMeta');
@@ -1341,6 +1342,18 @@ function toggleTheme() {
     showNotification(
         `Переключено на ${newTheme === "dark" ? "темну" : "світлу"} тему`
     );
+}
+
+function loadTheme() {
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme) {
+        document.body.setAttribute('data-theme', storedTheme);
+        const themeColorMeta = document.getElementById('themeColorMeta');
+        if (themeColorMeta) {
+            themeColorMeta.content =
+                storedTheme === 'dark' ? '#1a1a2e' : '#667eea';
+        }
+    }
 }
 
 function toggleFullscreen() {
@@ -1417,6 +1430,7 @@ function loadSettings() {
 
 // Ініціалізація після побудови DOM
 window.addEventListener("DOMContentLoaded", () => {
+    loadTheme();
     loadSpeedDataFromStorage();
     initChart();
     loadSettings();

--- a/styles/style.css
+++ b/styles/style.css
@@ -56,6 +56,7 @@ body {
   left: 0;
   width: 100%;
   height: 100vh;
+  overflow-y: auto;
   z-index: 9999;
   padding: 0;
   margin: 0;


### PR DESCRIPTION
## Summary
- allow body scrolling while in fullscreen mode
- remember chosen color theme between sessions
- load saved theme on page startup

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6856bf6c9ba88329ae9f1e7b4d3974f7