### PR TITLE
Introduce adaptive CSS variables

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -7,6 +7,11 @@
   --warning-color: #ff6b6b;
   --glass-bg: rgba(255, 255, 255, 0.1);
   --glass-border: rgba(255, 255, 255, 0.2);
+  /* common adaptive values */
+  --icon-btn-size: 50px;
+  --icon-btn-font-size: 1.2em;
+  --info-padding: 5px;
+  --info-font-size: 0.9em;
 }
 
 [data-theme="dark"] {
@@ -247,9 +252,9 @@ h1 {
 .info {
   background: var(--glass-bg);
   border-radius: 10px;
-  padding: 5px;
+  padding: var(--info-padding);
   margin: 5px 0;
-  font-size: 0.9em;
+  font-size: var(--info-font-size);
   border: 1px solid var(--glass-border);
   backdrop-filter: blur(10px);
 }
@@ -342,8 +347,8 @@ h1 {
 }
 
 .icon-btn {
-  width: 50px;
-  height: 50px;
+  width: var(--icon-btn-size);
+  height: var(--icon-btn-size);
   border-radius: 50%;
   border: none;
   background: var(--glass-bg);
@@ -354,7 +359,7 @@ h1 {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.2em;
+  font-size: var(--icon-btn-font-size);
   transition: all 0.3s ease;
 }
 
@@ -466,6 +471,12 @@ h1 {
 }
 
 @media (max-width: 768px) {
+  :root {
+    --icon-btn-size: 45px;
+    --icon-btn-font-size: 1.1em;
+    --info-padding: 15px 18px;
+    --info-font-size: 0.85em;
+  }
   body {
     align-items: flex-start;
     justify-content: center;
@@ -552,16 +563,10 @@ h1 {
     margin-bottom: 15px;
     order: -1;
   }
-  .icon-btn {
-    width: 45px;
-    height: 45px;
-    font-size: 1.1em;
-  }
+  /* icon buttons adjust via variables */
 
   .info {
     width: 100%;
-    padding: 15px 18px;
-    font-size: 0.85em;
     grid-template-columns: 1fr;
     row-gap: 10px;
   }
@@ -617,6 +622,10 @@ h1 {
 }
 
 @media (max-width: 480px) {
+  :root {
+    --info-padding: 12px 14px;
+    --info-font-size: 0.8em;
+  }
   .container {
     padding: 10px;
     border-radius: 10px;
@@ -643,8 +652,7 @@ h1 {
     height: 250px;
   }
   .info {
-    padding: 12px 14px;
-    font-size: 0.8em;
+    /* padding and font-size set via variables */
   }
 }
 .mb-20 { margin-bottom: 20px; }


### PR DESCRIPTION
## Summary
- add reusable dimension variables for icon buttons and info blocks
- update `.icon-btn` and `.info` to use variables
- override variables in responsive media queries and clean up duplicated properties

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857965aa53883298a7286f5e1179d1b