### PR TITLE
Adjust container border for mobile

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -499,6 +499,7 @@ h1 {
     width: 100%;
     max-width: 100%;
     margin: 0;
+    border: 0;
     border-radius: 15px;
     min-height: auto;
     max-height: none;
@@ -639,6 +640,7 @@ h1 {
   }
   .container {
     padding: 10px;
+    border: 0;
     border-radius: 10px;
   }
 


### PR DESCRIPTION
## Summary
- remove the default border on `.container` within the mobile media queries

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a4ab058988329b446cefa837b0a25