### PR TITLE
Fix icon URLs to use HTTPS

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -21,9 +21,9 @@ const MAX_DATA_POINTS = 60;
 const serverUrl = `https://speed.cloudflare.com/__down?bytes=${TARGET}`;
 const STORAGE_KEY = 'speedData';
 
-const ICON_RED = 'http://maps.google.com/mapfiles/kml/paddle/red-circle.png';
-const ICON_YELLOW = 'http://maps.google.com/mapfiles/kml/paddle/ylw-circle.png';
-const ICON_GREEN = 'http://maps.google.com/mapfiles/kml/paddle/grn-circle.png';
+const ICON_RED = 'https://maps.google.com/mapfiles/kml/paddle/red-circle.png';
+const ICON_YELLOW = 'https://maps.google.com/mapfiles/kml/paddle/ylw-circle.png';
+const ICON_GREEN = 'https://maps.google.com/mapfiles/kml/paddle/grn-circle.png';
 
 const DEFAULT_DIRECTION_LABELS = {
     uk: ["Пн", "ПнСх", "Сх", "ПдСх", "Пд", "ПдЗх", "Зх", "ПнЗх"],


### PR DESCRIPTION
## Summary
- update marker icon constants in `config.js` to use `https://` URLs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e3be7646483299b6df529bd82dcbc