### PR TITLE
Fix missing showNotification in HTML download

### DIFF
--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -1,6 +1,6 @@
 function downloadHTML() {
     if (speedData.length === 0) {
-        alert('Немає даних для завантаження');
+        showNotification(t('noData', 'Немає даних для завантаження'));
         return;
     }
 


### PR DESCRIPTION
## Summary
- replace `alert()` with `showNotification()` when no data is available for HTML download

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e40c05aa083299f73b2e75518ec8b