### PR TITLE
Handle Leaflet CDN failure

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
     <script defer src="js/settings.js"></script>
     <script defer src="js/add_event_listener.js"></script>
 
-    <script defer src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script defer src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" onerror="this.onerror=null;this.src='js/leaflet.stub.js'"></script>
 
     <link rel="preload"
           href="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"


### PR DESCRIPTION
## Summary
- handle Leaflet CDN loading failure by falling back to `leaflet.stub.js`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685e41ea751c83299df321ffceb73c20