### PR TITLE
Handle cache failures in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -47,12 +47,14 @@ const urlsToCache = [
 ];
 self.addEventListener('install', event => {
   // Pre-cache required resources and activate the service worker immediately
-  event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then(cache => cache.addAll(urlsToCache))
-      // Force waiting service worker to become active
-      .then(() => self.skipWaiting())
-  );
+  event.waitUntil((async () => {
+    const cache = await caches.open(CACHE_NAME);
+    const requests = urlsToCache.map(url =>
+      url.startsWith("http") ? new Request(url, { mode: "no-cors" }) : url
+    );
+    await Promise.allSettled(requests.map(req => cache.add(req)));
+    await self.skipWaiting();
+  })());
 });
 
 self.addEventListener('activate', event => {


### PR DESCRIPTION
## Summary
- avoid blocking installation if cache.addAll fails
- allow external resources to be cached with `no-cors` mode

## Testing
- `node -c sw.js`

------
https://chatgpt.com/codex/tasks/task_e_685e4a481cc483298c9f3ab0ce0962af