### PR TITLE
Display storage usage percent

### DIFF
--- a/js/update_records_count.js
+++ b/js/update_records_count.js
@@ -1,5 +1,13 @@
 function updateRecordsCount() {
     document.getElementById("recordsCount").textContent = speedData.length;
     const label = (window.i18n && window.i18n[currentLang] && window.i18n[currentLang].recordsCount) || 'Записів:';
-    document.getElementById("recordsInfo").textContent = `${label} ${speedData.length}`;
+    const infoEl = document.getElementById("recordsInfo");
+    infoEl.textContent = `${label} ${speedData.length}`;
+
+    if (navigator.storage && navigator.storage.estimate) {
+        navigator.storage.estimate().then(({ usage, quota }) => {
+            const percent = quota ? Math.round((usage / quota) * 100) : 0;
+            infoEl.textContent = `${label} ${speedData.length} (${percent}%)`;
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- display percent of Web Storage usage next to records count

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685e60fc65708329aef950d6ada02433