### PR TITLE
Refactor downloadHTML to reuse map marker helper

### DIFF
--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -35,6 +35,13 @@ function downloadHTML() {
         }
     }
 
+    const escapeForTemplate = (s) =>
+        s.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+
+    const addMapMarkerSrc = escapeForTemplate(window.addMapMarker.toString());
+    const getColorSrc = escapeForTemplate(window.getColorBySpeed.toString());
+    const popupSrc = escapeForTemplate(window.getMarkerPopupContent.toString());
+
     const htmlContent = `<!DOCTYPE html>
 <html>
 <head>
@@ -47,15 +54,15 @@ function downloadHTML() {
   <div id="map"></div>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script>
+    function t(key, fallback = '') { return fallback; }
     const data = ${JSON.stringify(speedData)};
-    function getColor(s){ if(s <= 0) return 'red'; if(s <= 2) return 'yellow'; return 'green'; }
+    ${getColorSrc}
+    ${popupSrc}
+    ${addMapMarkerSrc}
+    let mapMarkers = [];
     const map = L.map('map').setView([${center[0]}, ${center[1]}], 13);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom:19, attribution:'© OpenStreetMap'}).addTo(map);
-    data.forEach(pt => {
-      if(pt.latitude == null || pt.longitude == null) return;
-      const color = getColor(pt.speed);
-      L.circleMarker([pt.latitude, pt.longitude], {radius:6, color, fillColor:color, fillOpacity:0.8}).addTo(map);
-    });
+    data.forEach(pt => addMapMarker(pt, false));
   </script>
 </body>
 </html>`;

--- a/js/map.js
+++ b/js/map.js
@@ -101,3 +101,8 @@ function calculateDistance(lat1, lon1, lat2, lon2) {
     const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
     return R * c;
 }
+
+// Expose helper functions for reuse in other modules or generated HTML
+window.getColorBySpeed = getColorBySpeed;
+window.getMarkerPopupContent = getMarkerPopupContent;
+window.addMapMarker = addMapMarker;


### PR DESCRIPTION
## Summary
- expose `addMapMarker` and friends on `window` for reuse
- build downloaded HTML using these helper functions

## Testing
- `node --check js/download_HTML.js && node --check js/map.js`

------
https://chatgpt.com/codex/tasks/task_e_685e7abb5e9c832993b36e9dc269a6b6