### PR TITLE
Fix HTML export template literals

### DIFF
--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -35,12 +35,9 @@ function downloadHTML() {
         }
     }
 
-    const escapeForTemplate = (s) =>
-        s.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
-
-    const addMapMarkerSrc = escapeForTemplate(window.addMapMarker.toString());
-    const getColorSrc = escapeForTemplate(window.getColorBySpeed.toString());
-    const popupSrc = escapeForTemplate(window.getMarkerPopupContent.toString());
+    const addMapMarkerSrc = window.addMapMarker.toString();
+    const getColorSrc = window.getColorBySpeed.toString();
+    const popupSrc = window.getMarkerPopupContent.toString();
 
     const htmlContent = `<!DOCTYPE html>
 <html>


### PR DESCRIPTION
## Summary
- remove unnecessary escaping when embedding helper functions in downloaded HTML

This prevents stray backslashes from appearing in exported HTML and fixes invalid JavaScript.


------
https://chatgpt.com/codex/tasks/task_e_685eb4e31ff08329bf6f85b2da1545a6