### PR TITLE
Update universal width rule

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -31,7 +31,8 @@
   box-sizing: border-box;
 }
 
-*:not(html):not(body) {
+img,
+table {
   max-width: 100%;
 }
 html,


### PR DESCRIPTION
## Summary
- remove wide `*:not(html):not(body)` width rule
- limit max-width to `img` and `table` elements instead

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ec9a2cbcc8329b7ffa8ecb582d906