### PR TITLE
Fix operator reference in exported HTML

### DIFF
--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -52,6 +52,7 @@ function downloadHTML() {
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script>
     function t(key, fallback = '') { return fallback; }
+    const operator = ${JSON.stringify(operator)};
     const data = ${JSON.stringify(speedData)};
     ${getColorSrc}
     ${popupSrc}


### PR DESCRIPTION
## Summary
- embed current operator value when generating downloadable HTML

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ed897371c8329a0a233f161c7dfd1