### PR TITLE
Autofit track when exporting HTML

### DIFF
--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -58,9 +58,18 @@ function downloadHTML() {
     ${popupSrc}
     ${addMapMarkerSrc}
     let mapMarkers = [];
-    const map = L.map('map').setView([${center[0]}, ${center[1]}], 13);
+    const map = L.map('map');
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom:19, attribution:'© OpenStreetMap'}).addTo(map);
     data.forEach(pt => addMapMarker(pt, false));
+    const coords = data
+      .filter(pt => pt.latitude != null && pt.longitude != null)
+      .map(pt => [pt.latitude, pt.longitude]);
+    if (coords.length > 0) {
+      const bounds = L.latLngBounds(coords);
+      map.fitBounds(bounds.pad(0.05));
+    } else {
+      map.setView([${center[0]}, ${center[1]}], 13);
+    }
   </script>
 </body>
 </html>`;

--- a/js/leaflet.stub.js
+++ b/js/leaflet.stub.js
@@ -12,6 +12,10 @@
         this._zoom = zoom;
         return this;
       },
+      fitBounds(bounds) {
+        this._bounds = bounds;
+        return this;
+      },
       addLayer(layer) {
         if (layer && typeof layer.addTo === 'function') {
           layer.addTo(this);
@@ -36,6 +40,13 @@
         console.log('Stub circleMarker added to map', map);
         return this;
       }
+    };
+  };
+
+  L.latLngBounds = function(coords) {
+    return {
+      _coords: coords,
+      pad() { return this; }
     };
   };
 


### PR DESCRIPTION
## Summary
- ensure the exported map fits all recorded points
- extend the minimal Leaflet stub with `fitBounds` and `latLngBounds`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fa021d1cc8329b1d3d8e347c55b18