### PR TITLE
Persist settings via localStorage

### DIFF
--- a/js/add_event_listener.js
+++ b/js/add_event_listener.js
@@ -2,6 +2,7 @@
 window.addEventListener("DOMContentLoaded", () => {
     initLanguage();
     loadTheme();
+    loadSettingsFromStorage();
     loadSpeedDataFromStorage();
     initChart();
     loadSettings();

--- a/js/settings.js
+++ b/js/settings.js
@@ -3,6 +3,19 @@ function toggleSettings() {
     panel.classList.toggle("active");
 }
 
+const SETTINGS_STORAGE_KEY = 'settings';
+
+function loadSettingsFromStorage() {
+    const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
+    if (!stored) return;
+    try {
+        const loaded = JSON.parse(stored);
+        Object.assign(settings, loaded);
+    } catch (e) {
+        console.error('Failed to parse stored settings', e);
+    }
+}
+
 function saveSettings() {
     settings.saveInterval =
         parseInt(document.getElementById("saveInterval").value) || 1;
@@ -23,6 +36,8 @@ function saveSettings() {
             settings.saveInterval * 1000
         );
     }
+
+    localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings));
 
     showNotification(t('settingsSaved', 'Налаштування збережено!'));
     toggleSettings();


### PR DESCRIPTION
## Summary
- keep user settings between sessions
- load saved settings on startup before populating the settings UI

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686367476a04832983d9b2f5b33f8a43