### PR TITLE
Localize time unit labels

### DIFF
--- a/js/format_seconds.js
+++ b/js/format_seconds.js
@@ -7,19 +7,23 @@ function formatSeconds(totalSeconds) {
     // Створюємо масив для збереження частин часу
     const timeParts = [];
     
+    const hLabel = t('hoursShort', 'h');
+    const mLabel = t('minutesShort', 'm');
+    const sLabel = t('secondsShort', 's');
+
     // Додаємо години, якщо є
     if (hours > 0) {
-        timeParts.push(`${hours}h`);
+        timeParts.push(`${hours}${hLabel}`);
     }
-    
+
     // Додаємо хвилини, якщо є
     if (minutes > 0) {
-        timeParts.push(`${minutes}m`);
+        timeParts.push(`${minutes}${mLabel}`);
     }
-    
+
     // Додаємо секунди, якщо є або якщо це єдина частина
     if (seconds > 0 || timeParts.length === 0) {
-        timeParts.push(`${seconds}s`);
+        timeParts.push(`${seconds}${sLabel}`);
     }
     
     // З'єднуємо частини через пробіл

--- a/translations/en.js
+++ b/translations/en.js
@@ -92,5 +92,8 @@ window.i18n.en = {
   naValue: "N/A",
   firstPoint: "First point",
   unitMeters: "m",
+  hoursShort: "h",
+  minutesShort: "m",
+  secondsShort: "s",
   directionLabels: ["N", "NE", "E", "SE", "S", "SW", "W", "NW"]
 };

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -92,5 +92,8 @@ window.i18n.uk = {
   naValue: "Н/Д",
   firstPoint: "Перша точка",
   unitMeters: "м",
+  hoursShort: "г",
+  minutesShort: "хв",
+  secondsShort: "с",
   directionLabels: ["Пн", "ПнСх", "Сх", "ПдСх", "Пд", "ПдЗх", "Зх", "ПнЗх"]
 };


### PR DESCRIPTION
## Summary
- adjust `formatSeconds` to use localized hour/minute/second labels
- add short unit translations in `en.js` and `uk.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868ab2c5e488329a024a5c822f1aa73