### PR TITLE
Add localStorage byte usage estimation

### DIFF
--- a/js/update_records_count.js
+++ b/js/update_records_count.js
@@ -22,5 +22,19 @@ function updateRecordsCount() {
             });
             window.lastStoragePercent = percent;
         });
+    } else {
+        const percent = estimateLocalStoragePercent();
+        infoEl.textContent = `${label} ${speedData.length} (${percent}%)`;
     }
+}
+
+function estimateLocalStoragePercent() {
+    let total = 0;
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        const val = localStorage.getItem(key);
+        total += new Blob([key]).size + new Blob([val]).size;
+    }
+    const quota = 5 * 1024 * 1024; // 5MB fallback
+    return Math.round((total / quota) * 100);
 }


### PR DESCRIPTION
## Summary
- use `new Blob().size` to calculate fallback storage usage
- provide fallback storage percentage when `navigator.storage.estimate` is unavailable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868b6cff1ac83299120e856e880d6fd