### PR TITLE
Ensure provider detection on test start

### DIFF
--- a/js/speed_test.js
+++ b/js/speed_test.js
@@ -266,6 +266,9 @@ async function toggleTest() {
     if (!testInProgress) {
         testActive = true;
         document.getElementById("startBtn").textContent = t('stopTest', 'Зупинити тест');
+
+        await detectISP();
+
         addLog("Старт тесту");
         showNotification(t('testStarted', 'Тест запущено!'));
         initMapIfNeeded();


### PR DESCRIPTION
## Summary
- trigger `detectISP` when starting a test so the current provider is fetched first

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6869fd9189f88329b677b7af1ef5dcc7