### PR TITLE
Fix wake lock reacquisition

### DIFF
--- a/js/wake_lock.js
+++ b/js/wake_lock.js
@@ -4,9 +4,12 @@ let wakeLock = null;
 async function requestWakeLock() {
     try {
         wakeLock = await navigator.wakeLock.request('screen');
-        wakeLock.addEventListener('release', () => {
+        wakeLock.addEventListener('release', async () => {
             wakeLock = null;
             console.log('Wake Lock released');
+            if (document.visibilityState === 'visible') {
+                await requestWakeLock();
+            }
         });
     } catch (err) {
         console.error('Wake Lock error:', err);
@@ -14,7 +17,7 @@ async function requestWakeLock() {
 }
 
 document.addEventListener('visibilitychange', async () => {
-    if (wakeLock !== null && document.visibilityState === 'visible') {
+    if (document.visibilityState === 'visible') {
         await requestWakeLock();
     }
 });


### PR DESCRIPTION
## Summary
- ensure wake lock is re-requested when released
- retry acquiring wake lock whenever page becomes visible

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686a0617acd4832983408185af87be15