### PR TITLE
Store speed data in IndexedDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A minimal browser-based network speed test. The app runs entirely in the browser
 - GPS tracking with map view and recorded route
 - Sound and voice alerts
 - Works offline and can be installed as a PWA
+- Stores measurements locally using IndexedDB
 - Language selection
 - Export data to **CSV** or **KML**, download an **HTML** map, or save the speed chart as an image
 

--- a/js/add_event_listener.js
+++ b/js/add_event_listener.js
@@ -1,9 +1,9 @@
 // Ініціалізація після побудови DOM
-window.addEventListener("DOMContentLoaded", () => {
+window.addEventListener("DOMContentLoaded", async () => {
     initLanguage();
     loadTheme();
     loadSettingsFromStorage();
-    loadSpeedDataFromStorage();
+    await loadSpeedDataFromStorage();
     initChart();
     loadSettings();
     updateGPSInfo();

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,17 +1,57 @@
-function saveSpeedDataToStorage() {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(speedData));
-    updateRecordsCount();
+let db;
+
+function openDatabase() {
+    if (db) return Promise.resolve(db);
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open('gonettestDB', 1);
+        request.onupgradeneeded = () => {
+            const database = request.result;
+            if (!database.objectStoreNames.contains(STORAGE_KEY)) {
+                database.createObjectStore(STORAGE_KEY);
+            }
+        };
+        request.onerror = () => reject(request.error);
+        request.onsuccess = () => {
+            db = request.result;
+            resolve(db);
+        };
+    });
 }
 
-function loadSpeedDataFromStorage() {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-        try {
-            speedData = JSON.parse(stored);
-            chartData = speedData.slice(-maxDataPoints).map(d => ({ time: d.timestamp, speed: d.speed }));
-        } catch (e) {
+async function saveSpeedDataToStorage() {
+    const database = await openDatabase();
+    const tx = database.transaction(STORAGE_KEY, 'readwrite');
+    tx.objectStore(STORAGE_KEY).put(speedData, 'records');
+    return new Promise((resolve, reject) => {
+        tx.oncomplete = () => {
+            updateRecordsCount();
+            resolve();
+        };
+        tx.onerror = () => reject(tx.error);
+    });
+}
+
+async function loadSpeedDataFromStorage() {
+    const database = await openDatabase();
+    const tx = database.transaction(STORAGE_KEY, 'readonly');
+    const request = tx.objectStore(STORAGE_KEY).get('records');
+    return new Promise((resolve) => {
+        request.onsuccess = () => {
+            try {
+                speedData = request.result || [];
+                chartData = speedData
+                    .slice(-maxDataPoints)
+                    .map((d) => ({ time: d.timestamp, speed: d.speed }));
+            } catch (e) {
+                speedData = [];
+                chartData = [];
+            }
+            resolve();
+        };
+        request.onerror = () => {
             speedData = [];
             chartData = [];
-        }
-    }
+            resolve();
+        };
+    });
 }

--- a/js/update_records_count.js
+++ b/js/update_records_count.js
@@ -26,14 +26,9 @@ function updateRecordsCount() {
 }
 
 function estimateLocalStoragePercent() {
-    let total = 0;
-    for (let i = 0; i < localStorage.length; i++) {
-        const key = localStorage.key(i);
-        const val = localStorage.getItem(key);
-        total += new Blob([key]).size + new Blob([val]).size;
-    }
+    const dataSize = new Blob([JSON.stringify(speedData)]).size;
     const quota = 5 * 1024 * 1024; // 5MB fallback
-    return Math.round((total / quota) * 100);
+    return Math.round((dataSize / quota) * 100);
 }
 
 function notifyStorageThreshold(percent) {


### PR DESCRIPTION
## Summary
- store measurement records in IndexedDB instead of localStorage
- wait for DB load before initializing UI
- adjust storage usage estimation
- document new storage method in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687226c1741883298f6866ed9d45ef64