### PR TITLE
perf: reduce overhead in storage usage estimation

### DIFF
--- a/js/add_event_listener.js
+++ b/js/add_event_listener.js
@@ -1,5 +1,6 @@
 // Ініціалізація після побудови DOM
 window.addEventListener("DOMContentLoaded", async () => {
+    initStorageQuota();
     initLanguage();
     loadTheme();
     loadSettingsFromStorage();


### PR DESCRIPTION
## Summary
- cache serialized data size to reduce JSON operations
- fetch quota once at startup if possible
- initialize quota logic during DOM load

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68735b98579483299f06741e75a85cb0