### PR TITLE
Add clear data confirmation translations

### DIFF
--- a/js/clear_data.js
+++ b/js/clear_data.js
@@ -1,7 +1,7 @@
 function clearData() {
     if (speedData.length === 0) return;
 
-    if (confirm("Ви впевнені, що хочете очистити всі дані?")) {
+    if (confirm(t('clearDataConfirm', 'Ви впевнені, що хочете очистити всі дані?'))) {
         speedData = [];
         saveSpeedDataToStorage();
         chartData = [];

--- a/translations/en.js
+++ b/translations/en.js
@@ -60,6 +60,7 @@ window.i18n.en = {
   downloadHTML: "Download HTML",
   downloadChart: "Download speed chart",
   clearData: "Clear data",
+  clearDataConfirm: "Are you sure you want to clear all data?",
   ipLabel: "IP:",
   hostnameLabel: "Host:",
   cityLabel: "City:",

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -60,6 +60,7 @@ window.i18n.uk = {
   downloadHTML: "Завантажити HTML",
   downloadChart: "Завантажити графік швидкості",
   clearData: "Очистити дані",
+  clearDataConfirm: "Ви впевнені, що хочете очистити всі дані?",
   ipLabel: "IP:",
   hostnameLabel: "Хост:",
   cityLabel: "Місто:",


### PR DESCRIPTION
## Summary
- add `clearDataConfirm` key to `en.js` and `uk.js`
- use translated text for confirmation in `clear_data.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877e2225ea0832988d35f4c8ac622b0