### PR TITLE
Fix meta description spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Streaming data download speed test on the way">
+    <meta name="description"
+          content="Streaming data download speed test on the way">
     <meta id="themeColorMeta" name="theme-color" content="#1a1a2e" />
     <title data-i18n="appTitle">Тест швидкості інтернету</title>
 


### PR DESCRIPTION
## Summary
- wrap meta description across lines and ensure it includes a space in "on the way"

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6877e2e879148329a46d2728c91ab9eb