### PR TITLE
Refactor storage saving to update only latest record

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -21,7 +21,16 @@ function openDatabase() {
 async function saveSpeedDataToStorage() {
     const database = await openDatabase();
     const tx = database.transaction(STORAGE_KEY, 'readwrite');
-    tx.objectStore(STORAGE_KEY).put(speedData, 'records');
+    const store = tx.objectStore(STORAGE_KEY);
+
+    if (speedData.length === 0) {
+        store.clear();
+    } else {
+        const idx = speedData.length - 1;
+        const latest = speedData[idx];
+        store.put(latest, idx);
+    }
+
     return new Promise((resolve, reject) => {
         tx.oncomplete = () => {
             updateRecordsCount();
@@ -33,25 +42,49 @@ async function saveSpeedDataToStorage() {
 
 async function loadSpeedDataFromStorage() {
     const database = await openDatabase();
-    const tx = database.transaction(STORAGE_KEY, 'readonly');
-    const request = tx.objectStore(STORAGE_KEY).get('records');
-    return new Promise((resolve) => {
-        request.onsuccess = () => {
-            try {
-                speedData = request.result || [];
-                chartData = speedData
-                    .slice(-maxDataPoints)
-                    .map((d) => ({ time: d.timestamp, speed: d.speed }));
-            } catch (e) {
-                speedData = [];
-                chartData = [];
-            }
-            resolve();
+
+    // First transaction for reading existing data/legacy record
+    const readTx = database.transaction(STORAGE_KEY, 'readonly');
+    const store = readTx.objectStore(STORAGE_KEY);
+    const allReq = store.getAll();
+    const keysReq = store.getAllKeys();
+    const legacyReq = store.get('records');
+
+    const readResult = await new Promise(resolve => {
+        readTx.oncomplete = () => {
+            resolve({
+                values: allReq.result || [],
+                keys: keysReq.result || [],
+                legacy: legacyReq.result,
+            });
         };
-        request.onerror = () => {
-            speedData = [];
-            chartData = [];
-            resolve();
-        };
+        readTx.onerror = () => resolve({ values: [], keys: [], legacy: null });
     });
+
+    if (readResult.legacy !== undefined && readResult.legacy !== null) {
+        // Migrate legacy array stored under 'records'
+        speedData = readResult.legacy || [];
+
+        const writeTx = database.transaction(STORAGE_KEY, 'readwrite');
+        const writeStore = writeTx.objectStore(STORAGE_KEY);
+        writeStore.clear();
+        speedData.forEach((record, idx) => writeStore.put(record, idx));
+
+        await new Promise(resolve => {
+            writeTx.oncomplete = resolve;
+            writeTx.onerror = resolve;
+        });
+    } else {
+        // Build array from individual records
+        const pairs = readResult.keys.map((key, idx) => ({
+            key: Number(key),
+            value: readResult.values[idx],
+        }));
+        pairs.sort((a, b) => a.key - b.key);
+        speedData = pairs.map(p => p.value);
+    }
+
+    chartData = speedData
+        .slice(-maxDataPoints)
+        .map(d => ({ time: d.timestamp, speed: d.speed }));
 }


### PR DESCRIPTION
## Summary
- change `saveSpeedDataToStorage` to update only the newest data point or clear when empty
- load data by gathering individual records and migrate legacy `records` array if present

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877e40b7b3483299fec5b8502031f4b