### PR TITLE
Add administrative unit columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,6 +332,9 @@
             <div data-i18n="lonColumn">Довгота</div>
             <div data-i18n="altColumn">Висота</div>
             <div data-i18n="moveSpeedColumn">Швидкість руху км/год</div>
+            <div data-i18n="oblastColumn">Область</div>
+            <div data-i18n="raionColumn">Район</div>
+            <div data-i18n="hromadaColumn">Громада</div>
           </div>
           <div id="dataDisplay">
             <div class="text-center p-20 opacity-60" data-i18n="noData">

--- a/js/update_data_display.js
+++ b/js/update_data_display.js
@@ -14,15 +14,13 @@ function updateDataDisplay() {
                 <div class="data-row">
                     <div>${record.timestamp}</div>
                     <div>${record.speed.toFixed(2)}</div>
-                    <div>${record.latitude ? record.latitude.toFixed(6) : "N/A"
-                }</div>
-                    <div>${record.longitude ? record.longitude.toFixed(6) : "N/A"
-                }</div>
-                    <div>${record.altitude ? record.altitude.toFixed(1) : "N/A"
-                }</div>
-                    <div>${record.gpsSpeed
-                    ? record.gpsSpeed.toFixed(1) : "N/A"
-                }</div>
+                    <div>${record.latitude ? record.latitude.toFixed(6) : "N/A"}</div>
+                    <div>${record.longitude ? record.longitude.toFixed(6) : "N/A"}</div>
+                    <div>${record.altitude ? record.altitude.toFixed(1) : "N/A"}</div>
+                    <div>${record.gpsSpeed ? record.gpsSpeed.toFixed(1) : "N/A"}</div>
+                    <div>${record.region || 'N/A'}</div>
+                    <div>${record.rayon || 'N/A'}</div>
+                    <div>${record.hromada || 'N/A'}</div>
                 </div>
             `
         )

--- a/styles/style.css
+++ b/styles/style.css
@@ -411,7 +411,7 @@ h1 {
 
 .data-row {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: repeat(9, 1fr);
   gap: 10px;
   padding: 8px 0;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
@@ -605,7 +605,7 @@ h1 {
   .data-row {
     gap: 5px;
     font-size: 0.7em;
-    grid-template-columns: repeat(6, 1fr);
+    grid-template-columns: repeat(9, 1fr);
   }
 
   .data-header-row {


### PR DESCRIPTION
## Summary
- add oblast/raion/hromada header columns
- display region data in table rows
- expand `.data-row` grid to nine columns for desktop and mobile

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687806b8909083298777d7d115c9099e