### PR TITLE
Clamp invalid settings

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -16,13 +16,45 @@ function loadSettingsFromStorage() {
     }
 }
 
+function clampNumber(value, min, max, def) {
+    const num = parseFloat(value);
+    if (isNaN(num)) return { value: def, error: true };
+    if (num < min) return { value: min, error: true };
+    if (num > max) return { value: max, error: true };
+    return { value: num, error: false };
+}
+
 function saveSettings() {
-    settings.saveInterval =
-        parseInt(document.getElementById("saveInterval").value) || 1;
-    settings.gpsDistance =
-        parseFloat(document.getElementById("gpsDistance").value) || 1;
-    settings.speedThreshold =
-        parseFloat(document.getElementById("speedThreshold").value) || 5;
+    let hasError = false;
+    let result = clampNumber(
+        document.getElementById("saveInterval").value,
+        1,
+        60,
+        DEFAULT_SAVE_INTERVAL
+    );
+    settings.saveInterval = result.value;
+    document.getElementById("saveInterval").value = settings.saveInterval;
+    hasError = hasError || result.error;
+
+    result = clampNumber(
+        document.getElementById("gpsDistance").value,
+        0,
+        100,
+        10
+    );
+    settings.gpsDistance = result.value;
+    document.getElementById("gpsDistance").value = settings.gpsDistance;
+    hasError = hasError || result.error;
+
+    result = clampNumber(
+        document.getElementById("speedThreshold").value,
+        0,
+        1000,
+        5
+    );
+    settings.speedThreshold = result.value;
+    document.getElementById("speedThreshold").value = settings.speedThreshold;
+    hasError = hasError || result.error;
     settings.soundAlerts = document.getElementById("soundAlerts").checked;
     settings.voiceAlerts = document.getElementById("voiceAlerts").checked;
     settings.showHromady = document.getElementById("showHromady").checked;
@@ -51,7 +83,11 @@ function saveSettings() {
         updateRoadLayers();
     }
 
-    showNotification(t('settingsSaved', 'Налаштування збережено!'));
+    if (hasError) {
+        showNotification(t('settingsInvalid', 'Некоректні значення!'));
+    } else {
+        showNotification(t('settingsSaved', 'Налаштування збережено!'));
+    }
     toggleSettings();
 }
 

--- a/translations/en.js
+++ b/translations/en.js
@@ -96,6 +96,7 @@ window.i18n.en = {
   testStarted: "Test started!",
   testStopped: "Test stopped!",
   settingsSaved: "Settings saved!",
+  settingsInvalid: "Invalid values corrected!",
   fullscreenEnabled: "Fullscreen enabled",
   fullscreenDisabled: "Fullscreen disabled",
   themeSwitchedDark: "Switched to dark theme",

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -96,6 +96,7 @@ window.i18n.uk = {
   testStarted: "Тест запущено!",
   testStopped: "Тест зупинено!",
   settingsSaved: "Налаштування збережено!",
+  settingsInvalid: "Вказано некоректні значення!",
   fullscreenEnabled: "Повноекранний режим увімкнено",
   fullscreenDisabled: "Повноекранний режим вимкнено",
   themeSwitchedDark: "Переключено на темну тему",


### PR DESCRIPTION
## Summary
- prevent invalid configuration values in the settings dialog
- show an error when values are corrected
- add translations for the new error message

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68793d56dcc48329bfca2e88db88c957