### PR TITLE
Fix missing road number in KML exports

### DIFF
--- a/js/download_KML.js
+++ b/js/download_KML.js
@@ -71,6 +71,7 @@ function downloadKML() {
             `Область: ${record.region}<br>` +
             `Район: ${record.rayon}<br>` +
             `Громада: ${record.hromada}<br>` +
+            `Номер дороги: ${record.roadRef ?? ''}<br>` +
             `GPS Швидкість (км/год): ${record.gpsSpeed ? record.gpsSpeed.toFixed(1) : ''}<br>` +
             `Точність (м): ${record.accuracy ? record.accuracy.toFixed(1) : ''}<br>` +
             `Напрямок (°): ${record.heading ? record.heading.toFixed(1) : ''}`;


### PR DESCRIPTION
## Summary
- include road number when building the KML description

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68795240296c832999eac1f5d750b5c3