### PR TITLE
Fix small data size display

### DIFF
--- a/js/format_downloaded.js
+++ b/js/format_downloaded.js
@@ -1,12 +1,23 @@
 function formatDownloaded(bytes) {
-    const MB = 1024 * 1024;
+    const KB = 1024;
+    const MB = KB * 1024;
     const GB = MB * 1024;
+
     if (bytes >= GB) {
         const gb = Math.floor(bytes / GB);
         const mb = Math.floor((bytes % GB) / MB);
         return `${gb} GB ${mb} MB`;
-    } else {
-        const mb = Math.floor(bytes / MB);
+    }
+
+    if (bytes >= MB) {
+        const mb = (bytes / MB).toFixed(2);
         return `${mb} MB`;
     }
+
+    if (bytes >= KB) {
+        const kb = Math.round(bytes / KB);
+        return `${kb} KB`;
+    }
+
+    return `${bytes} B`;
 }

--- a/js/update_records_count.js
+++ b/js/update_records_count.js
@@ -37,7 +37,8 @@ function updateRecordsCount() {
         navigator.storage
             .estimate()
             .then(({ usage, quota }) => {
-                setInfo(usage);
+                const size = estimateLocalStoragePercent();
+                setInfo(size);
                 if (quota) {
                     const percent = Math.round((usage / quota) * 100);
                     notifyStorageThreshold(percent);


### PR DESCRIPTION
## Summary
- handle sub-megabyte values when formatting stored data size
- use internal estimate for data size in updateRecordsCount

## Testing
- `node -e "const fs=require('fs'); eval(fs.readFileSync('./js/format_downloaded.js','utf8')); console.log(formatDownloaded(512));"`
- `node -e "const fs=require('fs'); eval(fs.readFileSync('./js/format_downloaded.js','utf8')); console.log(formatDownloaded(3145728));"`

------
https://chatgpt.com/codex/tasks/task_e_687a420b81588329b8a911918a53a881