### PR TITLE
Fix download HTML escaping

### DIFF
--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -154,7 +154,7 @@ osm.addTo(map);
 /* ------------------ 5. Функція створення іконки кластера ------------------ */
 const makeClusterIconClass = (className) => cluster =>
   L.divIcon({
-    html: `<div class="speed-cluster ${className}">${cluster.getChildCount()}</div>`,
+    html: \`<div class="speed-cluster ${className}\">${cluster.getChildCount()}</div>\`,
     className: 'speed-cluster-wrapper',
     iconSize: [34, 34]
   });
@@ -182,12 +182,12 @@ let mapMarkers = [];
 
 /* ------------------ 8. Створення popup-контенту ------------------ */
 function getMarkerPopupContent(point) {
-  return `
+  return \`
     <div style="min-width:150px">
       <strong>Час:</strong> ${point.fullTimestamp || ''}<br/>
       <strong>Швидкість:</strong> ${point.speed != null ? point.speed.toFixed(2) : '—'} Мбіт/с
     </div>
-  `;
+  \`;
 }
 
 /* ------------------ 9. Додавання маркерів ------------------ */


### PR DESCRIPTION
## Summary
- escape backticks inside the generated HTML
- ensure `node --check` reports no errors

## Testing
- `node --check js/download_HTML.js`

------
https://chatgpt.com/codex/tasks/task_e_6884833ad8e48329913ee563dadb55c7