### PR TITLE
Fix exported marker size

### DIFF
--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -175,7 +175,7 @@ function addMapMarker(point) {
   const color = getColorBySpeed(point.speed);
 
   const marker = L.circleMarker([point.latitude, point.longitude], {
-    radius: 8,
+    radius: 18,
     color: color,
     weight: 2,
     fillColor: color,


### PR DESCRIPTION
## Summary
- increase the radius of the markers in the generated HTML

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6884855486388329b5d0ca136682a553