### PR TITLE
Fix download HTML memory leak

### DIFF
--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -227,6 +227,7 @@ L.control.layers(null, overlays, { collapsed: true }).addTo(map);
     link.download = `${baseFileName}.html`;
     document.body.appendChild(link);
     link.click();
+    URL.revokeObjectURL(link.href);
     document.body.removeChild(link);
 
     showNotification(t('htmlDownloaded', 'HTML файл завантажено!'));


### PR DESCRIPTION
## Summary
- clean up Blob object URL after link click in `download_HTML.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884865d73e08329aa730534ec2320cb