### PR TITLE
Fix downloadHTML issues

### DIFF
--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -1,4 +1,17 @@
 function downloadHTML() {
+    if (!Array.isArray(speedData)) {
+        console.error('speedData is undefined');
+        return;
+    }
+    if (typeof operator === 'undefined') {
+        console.error('operator is undefined');
+        return;
+    }
+    if (typeof t !== 'function' || typeof showNotification !== 'function') {
+        console.error('Required helpers are missing');
+        return;
+    }
+
     if (speedData.length === 0) {
         showNotification(t('noData', 'Немає даних для завантаження'));
         return;
@@ -17,11 +30,13 @@ function downloadHTML() {
             month: '2-digit',
             year: 'numeric',
         });
-        timeStr = ts.toLocaleTimeString('uk-UA', {
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit',
-        });
+        timeStr = ts
+            .toLocaleTimeString('uk-UA', {
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit',
+            })
+            .replace(/:/g, '-');
     }
 
     const baseFileName = `${replaceSpacesWithUnderscore(operator)}_${dateStr}_${timeStr}`;
@@ -155,6 +170,7 @@ const greenCluster = L.markerClusterGroup({
   iconCreateFunction: makeClusterIconClass('green')
 });
 
+/* ------------------ 7. Додавання кластерів на карту ------------------ */
 redCluster.addTo(map);
 yellowCluster.addTo(map);
 greenCluster.addTo(map);


### PR DESCRIPTION
## Summary
- add sanity checks for globals in `download_HTML.js`
- replace colons in time string to avoid invalid filenames
- insert missing step numbering for map clusters

## Testing
- `node -c js/download_HTML.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68848c88126c8329ba3fab7a37254f34