### PR TITLE
Fix missing popup content in exported HTML

### DIFF
--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -43,9 +43,7 @@ function downloadHTML() {
 
     const safeData = JSON.stringify(speedData).replace(/<\/script>/g, '<\\/script>');
 
-    let addMapMarkerSrc = window.addMapMarker
-        .toString()
-        .replace(/radius:\s*6/, 'radius: 18');
+    let getMarkerPopupContentSrc = window.getMarkerPopupContent.toString();
 
     const htmlContent = `
 <!DOCTYPE html>
@@ -180,7 +178,7 @@ yellowCluster.addTo(map);
 greenCluster.addTo(map);
 
 /* ------------------ 8. Створення popup-контенту ------------------ */
-${addMapMarkerSrc}
+${getMarkerPopupContentSrc}
 
 /* ------------------ 9. Додавання маркерів ------------------ */
 function addMapMarker(point) {


### PR DESCRIPTION
## Summary
- ensure exported HTML includes `getMarkerPopupContent` function

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68850092050c83299737b9b40921d0cf