### PR TITLE
Insert globals in generated HTML

### DIFF
--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -127,6 +127,9 @@ function downloadHTML() {
 <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
 
 <script>
+/* ------------------ 0. Глобальні значення ------------------ */
+const operator = ${JSON.stringify(operator)};
+const t = (key, fallback = '') => fallback;
 /* ------------------ 1. Параметри ------------------ */
 const DISABLE_CLUSTER_ZOOM = 18; // >= цього зума кластери вимикаються
 const COLOR_RED    = 'red';


### PR DESCRIPTION
## Summary
- embed operator and translation fallback constants in generated HTML
- regenerate HTML via `downloadHTML` and verify no reference errors

## Testing
- `node test_downloadHTML.js` (manual generation)
- `node run_generated.js` (manual verification)

------
https://chatgpt.com/codex/tasks/task_e_68850476a588832982ef3e289bb0a1df