### PR TITLE
Add marker clustering by speed

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
     <link href="styles/style.css" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
           onerror="this.onerror=null;this.href='styles/leaflet.css';">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css">
 
     <script defer src="js/registration_service_worker.js"></script>
 
@@ -70,6 +72,7 @@
     <script defer src="js/add_event_listener.js"></script>
 
     <script defer src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" onerror="this.onerror=null;this.src='js/leaflet.stub.js'"></script>
+    <script defer src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
 
     <link rel="preload"
           href="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"

--- a/js/clear_data.js
+++ b/js/clear_data.js
@@ -15,8 +15,10 @@ function clearData() {
             speedChart.update();
         }
 
-        if (typeof map !== 'undefined' && map && mapMarkers.length) {
-            mapMarkers.forEach(marker => map.removeLayer(marker));
+        if (typeof map !== 'undefined' && map) {
+            if (redCluster) redCluster.clearLayers();
+            if (yellowCluster) yellowCluster.clearLayers();
+            if (greenCluster) greenCluster.clearLayers();
             mapMarkers = [];
         }
         updateDataDisplay();

--- a/js/config.js
+++ b/js/config.js
@@ -25,6 +25,9 @@ const ICON_RED = 'https://maps.google.com/mapfiles/kml/paddle/red-circle.png';
 const ICON_YELLOW = 'https://maps.google.com/mapfiles/kml/paddle/ylw-circle.png';
 const ICON_GREEN = 'https://maps.google.com/mapfiles/kml/paddle/grn-circle.png';
 
+// Zoom level at which clustering is disabled on the main map
+const DISABLE_CLUSTER_ZOOM = 18;
+
 const DEFAULT_DIRECTION_LABELS = {
     uk: ["Пн", "ПнСх", "Сх", "ПдСх", "Пд", "ПдЗх", "Зх", "ПнЗх"],
     en: ["N", "NE", "E", "SE", "S", "SW", "W", "NW"],
@@ -94,6 +97,9 @@ let internationalRoadLayer = null;
 let nationalRoadLayer = null;
 let regionalRoadLayer = null;
 let territorialRoadLayer = null;
+let redCluster = null;
+let yellowCluster = null;
+let greenCluster = null;
 
 // Статистика
 let speedStats = {

--- a/js/map.js
+++ b/js/map.js
@@ -11,6 +11,37 @@ function initMap() {
         maxZoom: 19,
         attribution: '© OpenStreetMap'
     }).addTo(map);
+
+    // Initialize clustering groups for different speed ranges
+    const makeClusterIconClass = className => cluster =>
+        L.divIcon({
+            html: `<div class="speed-cluster ${className}">${cluster.getChildCount()}</div>`,
+            className: 'speed-cluster-wrapper',
+            iconSize: [34, 34]
+        });
+
+    redCluster = L.markerClusterGroup({
+        disableClusteringAtZoom: DISABLE_CLUSTER_ZOOM,
+        iconCreateFunction: makeClusterIconClass('red')
+    });
+    yellowCluster = L.markerClusterGroup({
+        disableClusteringAtZoom: DISABLE_CLUSTER_ZOOM,
+        iconCreateFunction: makeClusterIconClass('yellow')
+    });
+    greenCluster = L.markerClusterGroup({
+        disableClusteringAtZoom: DISABLE_CLUSTER_ZOOM,
+        iconCreateFunction: makeClusterIconClass('green')
+    });
+
+    redCluster.addTo(map);
+    yellowCluster.addTo(map);
+    greenCluster.addTo(map);
+
+    L.control.layers(null, {
+        [t('layerRed', 'Швидкість завантаження = 0 Мбіт/с (червоні)')]: redCluster,
+        [t('layerYellow', 'Швидкість завантаження до 2 Мбіт/с (жовті)')]: yellowCluster,
+        [t('layerGreen', 'Швидкість завантаження більше 2 Мбіт/с (зелені)')]: greenCluster
+    }, { collapsed: true }).addTo(map);
     mapInitialized = true;
     updateHromadyLayer();
     updateRoadLayers();
@@ -106,7 +137,17 @@ function addMapMarker(point, centerOnAdd = true) {
         color,
         fillColor: color,
         fillOpacity: 0.8,
-    }).addTo(map);
+    });
+
+    if (color === 'red' && redCluster) {
+        redCluster.addLayer(marker);
+    } else if (color === 'yellow' && yellowCluster) {
+        yellowCluster.addLayer(marker);
+    } else if (greenCluster) {
+        greenCluster.addLayer(marker);
+    } else {
+        marker.addTo(map);
+    }
     if (typeof marker.bindPopup === 'function') {
         marker.bindPopup(getMarkerPopupContent(point));
     }

--- a/styles/style.css
+++ b/styles/style.css
@@ -731,3 +731,34 @@ h1 {
   color: var(--success-color);
   font-weight: 600;
 }
+
+/* Custom cluster icons */
+.speed-cluster {
+  border-radius: 50%;
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 12px;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.35);
+  border: 2px solid #333;
+  color: #fff;
+  user-select: none;
+}
+.speed-cluster.red {
+  background: red;
+  border-color: red;
+  color: black;
+}
+.speed-cluster.yellow {
+  background: yellow;
+  border-color: yellow;
+  color: black;
+}
+.speed-cluster.green {
+  background: green;
+  border-color: green;
+  color: black;
+}


### PR DESCRIPTION
## Summary
- load Leaflet markercluster assets
- add cluster groups when initializing the map
- assign markers to groups by speed
- clear markers via cluster groups
- style custom cluster icons

## Testing
- `node -c js/map.js`
- `node -c js/clear_data.js`
- `node -c js/config.js`


------
https://chatgpt.com/codex/tasks/task_e_6885083f18c08329b0e47405f869a844