### PR TITLE
Add road statistics block and updater

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
     <script defer src="js/update_data_display.js"></script>
     <script defer src="js/update_database_info.js"></script>
     <script defer src="js/update_speed_distribution.js"></script>
+    <script defer src="js/update_road_stats.js"></script>
     <script defer src="js/replace_spaces_with_underscore.js"></script>
     <script defer src="js/download_CSV.js"></script>
     <script defer src="js/download_KML.js"></script>
@@ -348,6 +349,13 @@
           <div class="info-row"><span data-i18n="roadNameLabel">Назва дороги:</span><span id="roadName">-</span></div>
           <div class="info-row"><span data-i18n="roadDistanceLabel">Довжина (км):</span><span id="roadDistance">-</span></div>
           <div class="info-row"><span data-i18n="roadNetworkLabel">Тип:</span><span id="roadNetwork">-</span></div>
+        </div>
+
+        <div class="info" id="roadStats">
+          <div class="fw-bold mb-10" data-i18n="roadStatsTitle">Статистика автомобільних доріг</div>
+          <div id="roadStatsContent">
+            <div class="info-row"><span data-i18n="noData">Немає даних</span><span></span></div>
+          </div>
         </div>
 
       <div class="map-section">

--- a/js/update_database_info.js
+++ b/js/update_database_info.js
@@ -63,6 +63,10 @@ function updateDatabaseInfo() {
     if (typeof updateSpeedDistribution === 'function') {
         updateSpeedDistribution();
     }
+
+    if (typeof updateRoadStats === 'function') {
+        updateRoadStats();
+    }
 }
 
 function estimateLocalStorageSize() {

--- a/js/update_road_stats.js
+++ b/js/update_road_stats.js
@@ -1,0 +1,43 @@
+function updateRoadStats() {
+    const container = document.getElementById('roadStatsContent');
+    if (!container) return;
+
+    const stats = {};
+    for (const rec of speedData) {
+        if (!rec.roadRef) continue;
+        if (!stats[rec.roadRef]) {
+            stats[rec.roadRef] = { total: 0, zero: 0, upto2: 0, above2: 0 };
+        }
+        const s = stats[rec.roadRef];
+        s.total++;
+        if (rec.speed === 0) {
+            s.zero++;
+        } else if (rec.speed > 0 && rec.speed <= 2) {
+            s.upto2++;
+        } else {
+            s.above2++;
+        }
+    }
+
+    const keys = Object.keys(stats).sort();
+    if (keys.length === 0) {
+        container.innerHTML = `<div class="info-row"><span>${t('noData', 'Немає даних')}</span><span></span></div>`;
+        return;
+    }
+
+    const rows = [];
+    for (const road of keys) {
+        const s = stats[road];
+        const zp = Math.round((s.zero / s.total) * 100);
+        const up = Math.round((s.upto2 / s.total) * 100);
+        const ap = Math.round((s.above2 / s.total) * 100);
+        rows.push(
+            `<div class="info-row"><span>${road}</span><span>${s.total}</span></div>` +
+            `<div class="info-row"><span>${t('zeroSpeedLabel', '0 Мбіт/с:')}</span><span>${s.zero} (${zp}%)</span></div>` +
+            `<div class="info-row"><span>${t('upTo2SpeedLabel', 'До 2 Мбіт/с:')}</span><span>${s.upto2} (${up}%)</span></div>` +
+            `<div class="info-row"><span>${t('above2SpeedLabel', 'Більше 2 Мбіт/с:')}</span><span>${s.above2} (${ap}%)</span></div>`
+        );
+    }
+
+    container.innerHTML = rows.join('');
+}

--- a/translations/en.js
+++ b/translations/en.js
@@ -52,6 +52,7 @@ window.i18n.en = {
   dbRecordsLabel: "Records",
   dbSizeLabel: "Size",
   speedStatsTitle: "Download speed statistics",
+  roadStatsTitle: "Road statistics",
   zeroSpeedLabel: "0 Mbps:",
   upTo2SpeedLabel: "Up to 2 Mbps:",
   above2SpeedLabel: "Above 2 Mbps:",

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -52,6 +52,7 @@ window.i18n.uk = {
   dbRecordsLabel: "Записів",
   dbSizeLabel: "Розмір",
   speedStatsTitle: "Статистика швидкості завантаження",
+  roadStatsTitle: "Статистика автомобільних доріг",
   zeroSpeedLabel: "0 Мбіт/с:",
   upTo2SpeedLabel: "До 2 Мбіт/с:",
   above2SpeedLabel: "Більше 2 Мбіт/с:",


### PR DESCRIPTION
## Summary
- add a new **Статистика автомобільних доріг** block in the UI
- implement `updateRoadStats` module to show per-road counts and speed buckets
- refresh road statistics whenever database info is updated
- include translations for the new block

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885df7c77a48329b8759e536c00c98f