### PR TITLE
Add admin unit stats block

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
     <script defer src="js/update_database_info.js"></script>
     <script defer src="js/update_speed_distribution.js"></script>
     <script defer src="js/update_road_stats.js"></script>
+    <script defer src="js/update_admin_stats.js"></script>
     <script defer src="js/replace_spaces_with_underscore.js"></script>
     <script defer src="js/download_CSV.js"></script>
     <script defer src="js/download_KML.js"></script>
@@ -342,6 +343,13 @@
           <div class="info-row"><span data-i18n="raionLabel">Район:</span><span id="raion">-</span></div>
           <div class="info-row"><span data-i18n="hromadaLabel">Громада:</span><span id="hromada">-</span></div>
         </div>
+        <div class="info" id="adminStats">
+          <div class="fw-bold mb-10" data-i18n="adminStatsTitle">Статистика адміністративних одиниць</div>
+          <div id="adminStatsContent">
+            <div class="info-row"><span data-i18n="noData">Немає даних</span><span></span></div>
+          </div>
+        </div>
+
 
         <div class="info" id="roadInfo">
           <div class="fw-bold mb-10" data-i18n="roadInfoTitle">Поточна автомобільна дорога</div>

--- a/js/update_admin_stats.js
+++ b/js/update_admin_stats.js
@@ -1,0 +1,97 @@
+function updateAdminStats() {
+    const container = document.getElementById('adminStatsContent');
+    if (!container) return;
+
+    const stats = {};
+    for (const rec of speedData) {
+        if (!rec.region) continue;
+        if (!stats[rec.region]) {
+            stats[rec.region] = { total: 0, zero: 0, upto2: 0, above2: 0, raions: {} };
+        }
+        const reg = stats[rec.region];
+        reg.total++;
+        if (rec.speed === 0) reg.zero++;
+        else if (rec.speed > 0 && rec.speed <= 2) reg.upto2++;
+        else reg.above2++;
+
+        if (rec.rayon) {
+            if (!reg.raions[rec.rayon]) {
+                reg.raions[rec.rayon] = { total: 0, zero: 0, upto2: 0, above2: 0, hromady: {} };
+            }
+            const ray = reg.raions[rec.rayon];
+            ray.total++;
+            if (rec.speed === 0) ray.zero++;
+            else if (rec.speed > 0 && rec.speed <= 2) ray.upto2++;
+            else ray.above2++;
+
+            if (rec.hromada) {
+                if (!ray.hromady[rec.hromada]) {
+                    ray.hromady[rec.hromada] = { total: 0, zero: 0, upto2: 0, above2: 0 };
+                }
+                const h = ray.hromady[rec.hromada];
+                h.total++;
+                if (rec.speed === 0) h.zero++;
+                else if (rec.speed > 0 && rec.speed <= 2) h.upto2++;
+                else h.above2++;
+            }
+        }
+    }
+
+    const regions = Object.keys(stats).sort();
+    if (regions.length === 0) {
+        container.innerHTML = `<div class="info-row"><span>${t('noData', 'Немає даних')}</span><span></span></div>`;
+        return;
+    }
+
+    let id = 0;
+    const rows = [];
+    const pct = (v, tot) => (tot ? Math.round((v / tot) * 100) : 0);
+    const speedRows = (obj, indent) =>
+        `<div class="info-row" style="padding-left:${indent}px"><span>${t('zeroSpeedLabel', '0 Мбіт/с:')}</span><span>${obj.zero} (${pct(obj.zero, obj.total)}%)</span></div>` +
+        `<div class="info-row" style="padding-left:${indent}px"><span>${t('upTo2SpeedLabel', 'До 2 Мбіт/с:')}</span><span>${obj.upto2} (${pct(obj.upto2, obj.total)}%)</span></div>` +
+        `<div class="info-row" style="padding-left:${indent}px"><span>${t('above2SpeedLabel', 'Більше 2 Мбіт/с:')}</span><span>${obj.above2} (${pct(obj.above2, obj.total)}%)</span></div>`;
+
+    for (const regName of regions) {
+        const reg = stats[regName];
+        const regId = `reg-${id++}`;
+        rows.push(
+            `<div class="info-row admin-toggle" data-target="${regId}"><span><i data-lucide="plus"></i> ${regName}</span><span>${reg.total}</span></div>`
+        );
+        let sub = speedRows(reg, 0);
+        const raions = Object.keys(reg.raions).sort();
+        for (const rayName of raions) {
+            const ray = reg.raions[rayName];
+            const rayId = `ray-${id++}`;
+            sub +=
+                `<div class="info-row admin-toggle" data-target="${rayId}" style="padding-left:15px"><span><i data-lucide="plus"></i> ${rayName}</span><span>${ray.total}</span></div>` +
+                `<div id="${rayId}" class="admin-content hidden" style="padding-left:15px">` +
+                speedRows(ray, 15);
+            const hroms = Object.keys(ray.hromady).sort();
+            for (const hName of hroms) {
+                const h = ray.hromady[hName];
+                sub +=
+                    `<div class="info-row" style="padding-left:30px"><span>${hName}</span><span>${h.total}</span></div>` +
+                    speedRows(h, 30);
+            }
+            sub += `</div>`;
+        }
+        rows.push(`<div id="${regId}" class="admin-content hidden">${sub}</div>`);
+    }
+
+    container.innerHTML = rows.join('');
+    if (window.lucide) lucide.createIcons({ strokeWidth: 1.2, class: 'h-4 w-4' });
+
+    container.querySelectorAll('.admin-toggle').forEach(el => {
+        const target = el.dataset.target;
+        const icon = el.querySelector('i');
+        el.addEventListener('click', () => {
+            const cont = document.getElementById(target);
+            if (!cont) return;
+            cont.classList.toggle('hidden');
+            if (icon) {
+                icon.setAttribute('data-lucide', cont.classList.contains('hidden') ? 'plus' : 'minus');
+                if (window.lucide) lucide.createIcons({ strokeWidth: 1.2, class: 'h-4 w-4' });
+            }
+        });
+    });
+}

--- a/js/update_database_info.js
+++ b/js/update_database_info.js
@@ -67,6 +67,9 @@ function updateDatabaseInfo() {
     if (typeof updateRoadStats === 'function') {
         updateRoadStats();
     }
+    if (typeof updateAdminStats === "function") {
+        updateAdminStats();
+    }
 }
 
 function estimateLocalStorageSize() {

--- a/styles/style.css
+++ b/styles/style.css
@@ -762,3 +762,6 @@ h1 {
   border-color: green;
   color: black;
 }
+.hidden { display: none; }
+.admin-toggle { cursor: pointer; user-select: none; }
+.admin-content { padding-left: 0; }

--- a/translations/en.js
+++ b/translations/en.js
@@ -53,6 +53,7 @@ window.i18n.en = {
   dbSizeLabel: "Size",
   speedStatsTitle: "Download speed statistics",
   roadStatsTitle: "Road statistics",
+  adminStatsTitle: "Administrative unit statistics",
   zeroSpeedLabel: "0 Mbps:",
   upTo2SpeedLabel: "Up to 2 Mbps:",
   above2SpeedLabel: "Above 2 Mbps:",

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -53,6 +53,7 @@ window.i18n.uk = {
   dbSizeLabel: "Розмір",
   speedStatsTitle: "Статистика швидкості завантаження",
   roadStatsTitle: "Статистика автомобільних доріг",
+  adminStatsTitle: "Статистика адміністративних одиниць",
   zeroSpeedLabel: "0 Мбіт/с:",
   upTo2SpeedLabel: "До 2 Мбіт/с:",
   above2SpeedLabel: "Більше 2 Мбіт/с:",


### PR DESCRIPTION
## Summary
- compute hierarchical statistics for administrative units
- display admin stats in new expandable block
- load new module in index
- update translations and styles
- trigger stats update after saving data

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885e3ec9410832989eb242cca652fc2