### PR TITLE
Add zoom 18 button

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
   <script defer src="js/chart.js"></script>
   <script defer src="js/update_stats.js"></script>
   <script defer src="js/map.js"></script>
+  <script defer src="js/map_zoom.js"></script>
   <script defer src="js/find_admin_unit.js"></script>
   <script defer src="js/update_GPS_info.js"></script>
   <script defer src="js/GPS.js"></script>
@@ -249,6 +250,9 @@
 
       <div class="map-section">
         <div id="map"></div>
+        <button id="zoom18Btn" class="icon-btn map-zoom-btn" onclick="zoomTo18()" aria-label="Масштаб 18" data-i18n-aria="zoom18Aria">
+          <i data-lucide="zoom-in"></i>
+        </button>
       </div>
 
       <!-- Розширена GPS інформація -->

--- a/js/add_event_listener.js
+++ b/js/add_event_listener.js
@@ -14,6 +14,10 @@ window.addEventListener("DOMContentLoaded", async () => {
     updateDataDisplay();
     updateDatabaseInfo();
 
+    if (window.lucide) {
+        lucide.createIcons({ strokeWidth: 1.5, class: 'h-6 w-6' });
+    }
+
     // Обробка виходу з повноекранного режиму
     document.addEventListener("fullscreenchange", () => {
         if (!document.fullscreenElement && isFullscreen) {

--- a/js/map_zoom.js
+++ b/js/map_zoom.js
@@ -1,0 +1,8 @@
+function zoomTo18() {
+    if (typeof initMapIfNeeded === 'function') {
+        initMapIfNeeded();
+    }
+    if (map) {
+        map.setZoom(18);
+    }
+}

--- a/styles/style.css
+++ b/styles/style.css
@@ -434,8 +434,18 @@ h1 {
   opacity: 0.8;
 }
 
+# Add position relative to contain absolute controls
 .map-section {
+  position: relative;
   margin-top: 5px;
+}
+
+/* Button for zooming map to level 18 */
+.map-zoom-btn {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  z-index: 1000;
 }
 
 #map {

--- a/translations/en.js
+++ b/translations/en.js
@@ -6,6 +6,7 @@ window.i18n.en = {
   fullscreenAria: "Fullscreen",
   settingsAria: "Settings",
   refreshAria: "Refresh",
+  zoom18Aria: "Zoom to level 18",
   settingsTitle: "Settings",
   saveIntervalLabel: "Data save interval (seconds):",
   gpsDistanceLabel: "Minimum GPS distance to save (meters):",

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -6,6 +6,7 @@ window.i18n.uk = {
   fullscreenAria: "Повноекранний",
   settingsAria: "Налаштування",
   refreshAria: "Оновити",
+  zoom18Aria: "Масштаб 18",
   settingsTitle: "Налаштування",
   saveIntervalLabel: "Інтервал збереження даних (секунди):",
   gpsDistanceLabel: "Мінімальна відстань для збереження GPS (метри):",


### PR DESCRIPTION
## Summary
- add a button overlay to zoom map to level 18
- include map zoom script
- translate label for zoom button
- ensure lucide icons are processed on load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68862b3b5ee48329b4435680f0c464aa