### PR TITLE
Add indent-aware info row underline

### DIFF
--- a/js/update_admin_stats.js
+++ b/js/update_admin_stats.js
@@ -47,9 +47,9 @@ function updateAdminStats() {
     const rows = [];
     const pct = (v, tot) => (tot ? Math.round((v / tot) * 100) : 0);
     const speedRows = (obj, indent) =>
-        `<div class="info-row" style="padding-left:${indent}px"><span>${t('zeroSpeedLabel', '0 Мбіт/с:')}</span><span>${obj.zero} (${pct(obj.zero, obj.total)}%)</span></div>` +
-        `<div class="info-row" style="padding-left:${indent}px"><span>${t('upTo2SpeedLabel', 'До 2 Мбіт/с:')}</span><span>${obj.upto2} (${pct(obj.upto2, obj.total)}%)</span></div>` +
-        `<div class="info-row" style="padding-left:${indent}px"><span>${t('above2SpeedLabel', 'Більше 2 Мбіт/с:')}</span><span>${obj.above2} (${pct(obj.above2, obj.total)}%)</span></div>`;
+        `<div class="info-row" style="--indent:${indent}px"><span>${t('zeroSpeedLabel', '0 Мбіт/с:')}</span><span>${obj.zero} (${pct(obj.zero, obj.total)}%)</span></div>` +
+        `<div class="info-row" style="--indent:${indent}px"><span>${t('upTo2SpeedLabel', 'До 2 Мбіт/с:')}</span><span>${obj.upto2} (${pct(obj.upto2, obj.total)}%)</span></div>` +
+        `<div class="info-row" style="--indent:${indent}px"><span>${t('above2SpeedLabel', 'Більше 2 Мбіт/с:')}</span><span>${obj.above2} (${pct(obj.above2, obj.total)}%)</span></div>`;
 
     for (const regName of regions) {
         const reg = stats[regName];
@@ -63,14 +63,14 @@ function updateAdminStats() {
             const ray = reg.raions[rayName];
             const rayId = `ray-${id++}`;
             sub +=
-                `<div class="info-row admin-toggle" data-target="${rayId}" style="padding-left:30px"><span><i data-lucide="plus"></i> ${rayName}</span><span>${ray.total}</span></div>` +
+                `<div class="info-row admin-toggle" data-target="${rayId}" style="--indent:30px"><span><i data-lucide="plus"></i> ${rayName}</span><span>${ray.total}</span></div>` +
                 `<div id="${rayId}" class="admin-content hidden" style="padding-left:30px">` +
                 speedRows(ray, 30);
             const hroms = Object.keys(ray.hromady).sort();
             for (const hName of hroms) {
                 const h = ray.hromady[hName];
                 sub +=
-                    `<div class="info-row" style="padding-left:60px"><span>${hName}</span><span>${h.total}</span></div>` +
+                    `<div class="info-row" style="--indent:60px"><span>${hName}</span><span>${h.total}</span></div>` +
                     speedRows(h, 60);
             }
             sub += `</div>`;

--- a/styles/style.css
+++ b/styles/style.css
@@ -282,10 +282,18 @@ h1 {
   justify-content: space-between;
   margin: 5px 0;
   padding-bottom: 4px;
+  position: relative;
+  padding-left: var(--indent, 0);
+}
+.info-row::after {
+  content: "";
+  position: absolute;
+  left: var(--indent, 0);
+  right: 0;
+  bottom: 0;
   border-bottom: 1px solid var(--glass-border);
 }
-
-.info-row:last-child {
+.info-row:last-child::after {
   border-bottom: none;
 }
 


### PR DESCRIPTION
## Summary
- use a pseudo-element for `.info-row` underline and support `--indent`
- keep mobile styles intact
- update admin stats script to supply `--indent` instead of padding

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68864e5079c8832990dcaec5119632b2