### PR TITLE
Fix vertical centering of admin stats entries

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -301,6 +301,9 @@ h1 {
 .info-row span:first-child {
   font-weight: 600;
   opacity: 0.85;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .info-row span:last-child {


### PR DESCRIPTION
## Summary
- align admin stats text and icons using flexbox

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6886573117e08329871a40c01044fd7b