### PR TITLE
Add voice announcement for road changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
     <script defer src="js/map_zoom.js"></script>
     <script defer src="js/find_admin_unit.js"></script>
     <script defer src="js/hromada_change_announcer.js"></script>
+    <script defer src="js/road_change_announcer.js"></script>
     <script defer src="js/update_GPS_info.js"></script>
   <script defer src="js/GPS.js"></script>
   <script defer src="js/data_point.js"></script>
@@ -148,6 +149,12 @@
           <div class="checkbox-group">
             <input type="checkbox" id="voiceHromadaChange" />
             <label class="setting-label" for="voiceHromadaChange" data-i18n="voiceHromadaChangeLabel">Озвучувати зміну громади</label>
+          </div>
+        </div>
+        <div class="setting-group">
+          <div class="checkbox-group">
+            <input type="checkbox" id="voiceRoadChange" />
+            <label class="setting-label" for="voiceRoadChange" data-i18n="voiceRoadChangeLabel">Озвучувати зміну дороги</label>
           </div>
         </div>
         <div class="setting-group">

--- a/js/config.js
+++ b/js/config.js
@@ -77,6 +77,7 @@ let settings = {
     soundAlerts: true,
     voiceAlerts: false,
     voiceHromadaChange: false,
+    voiceRoadChange: false,
     showHromady: false,
     showInternationalRoads: false,
     showNationalRoads: false,

--- a/js/road_change_announcer.js
+++ b/js/road_change_announcer.js
@@ -1,0 +1,28 @@
+// js/road_change_announcer.js
+let lastRoad = { ref: null, name: null, network: null };
+
+function announceRoadChange(road) {
+    if (!road) {
+        lastRoad = { ref: null, name: null, network: null };
+        return;
+    }
+
+    const currentRef = road.ref || null;
+    const currentName = road.official_name || road['name:uk'] || road.name || null;
+    const currentNetwork = road.network || null;
+
+    if (settings.voiceRoadChange && settings.voiceAlerts && lastRoad.ref) {
+        if (
+            lastRoad.ref !== currentRef ||
+            lastRoad.name !== currentName ||
+            lastRoad.network !== currentNetwork
+        ) {
+            const refPart = currentRef ? `${currentRef}` : '';
+            const namePart = currentName ? `${currentName}` : '';
+            const networkPart = currentNetwork ? `${currentNetwork}` : '';
+            speak(`Ви виїхали на дорогу ${refPart} ${namePart} ${networkPart}`.trim());
+        }
+    }
+
+    lastRoad = { ref: currentRef, name: currentName, network: currentNetwork };
+}

--- a/js/settings.js
+++ b/js/settings.js
@@ -58,6 +58,7 @@ function saveSettings() {
     settings.soundAlerts = document.getElementById("soundAlerts").checked;
     settings.voiceAlerts = document.getElementById("voiceAlerts").checked;
     settings.voiceHromadaChange = document.getElementById("voiceHromadaChange").checked;
+    settings.voiceRoadChange = document.getElementById("voiceRoadChange").checked;
     settings.showHromady = document.getElementById("showHromady").checked;
     settings.showInternationalRoads = document.getElementById("showInternationalRoads").checked;
     settings.showNationalRoads = document.getElementById("showNationalRoads").checked;
@@ -100,6 +101,7 @@ function loadSettings() {
     document.getElementById("soundAlerts").checked = settings.soundAlerts;
     document.getElementById("voiceAlerts").checked = settings.voiceAlerts;
     document.getElementById("voiceHromadaChange").checked = settings.voiceHromadaChange;
+    document.getElementById("voiceRoadChange").checked = settings.voiceRoadChange;
     document.getElementById("showHromady").checked = settings.showHromady;
     document.getElementById("showInternationalRoads").checked = settings.showInternationalRoads;
     document.getElementById("showNationalRoads").checked = settings.showNationalRoads;

--- a/js/update_GPS_info.js
+++ b/js/update_GPS_info.js
@@ -170,6 +170,7 @@ async function updateRoadInfo() {
     }
 
     const road = find_road(currentGPSData.longitude, currentGPSData.latitude);
+    announceRoadChange(road);
 
     if (road) {
         refEl.textContent = road.ref || '-';

--- a/translations/en.js
+++ b/translations/en.js
@@ -14,6 +14,7 @@ window.i18n.en = {
   soundAlertsLabel: "Sound alerts",
   voiceAlertsLabel: "Voice alerts",
   voiceHromadaChangeLabel: "Announce community change",
+  voiceRoadChangeLabel: "Announce road change",
   showHromadyLabel: "Show community boundaries",
   showInternationalRoadsLabel: "Show international roads",
   showNationalRoadsLabel: "Show national roads",

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -14,6 +14,7 @@ window.i18n.uk = {
   soundAlertsLabel: "Звукові сповіщення",
   voiceAlertsLabel: "Голосові сповіщення",
   voiceHromadaChangeLabel: "Озвучувати зміну громади",
+  voiceRoadChangeLabel: "Озвучувати зміну дороги",
   showHromadyLabel: "Відображати межі громад",
   showInternationalRoadsLabel: "Відображати міжнародні дороги",
   showNationalRoadsLabel: "Відображати національні дороги",


### PR DESCRIPTION
## Summary
- add new checkbox in settings to toggle road change voice alerts
- handle saving/loading of `voiceRoadChange` in settings
- include `voiceRoadChange` default option in config
- announce road changes in a new module `road_change_announcer.js`
- trigger announcements during GPS updates
- add translations for the new label

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887877d225c8329976506d187c71bdc