### PR TITLE
Fix service worker cache list

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -31,7 +31,6 @@ const urlsToCache = [
   'js/toggle_theme.js',
   'js/update_data_display.js',
   'js/update_GPS_info.js',
-  'js/update_records_count.js',
   'js/update_stats.js',
   'js/update_UI.js', 
   'js/wake_lock.js', 


### PR DESCRIPTION
## Summary
- remove missing `update_records_count.js` from `urlsToCache`

## Testing
- `node - <<'EOF'
const fs=require('fs'); const sw=fs.readFileSync('sw.js','utf8'); const match=sw.match(/const urlsToCache = \[(.|\n)*?\];/); if(!match){console.error('array not found');process.exit(1);} const arrayString=match[0].replace(/const urlsToCache =/,'').replace(/;$/,''); const urls=eval(arrayString); const missing=urls.filter(u=>!u.startsWith('http')&&!fs.existsSync(u)); if(missing.length){console.error('Missing files:',missing); process.exit(1);} console.log('All local files exist');
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68878f0c3c008329a5d9434c74005127