### PR TITLE
Add distance column and calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
     <script defer src="js/hromada_change_announcer.js"></script>
     <script defer src="js/road_change_announcer.js"></script>
     <script defer src="js/update_GPS_info.js"></script>
+    <script defer src="js/point_distance.js"></script>
   <script defer src="js/GPS.js"></script>
   <script defer src="js/data_point.js"></script>
   <script defer src="js/update_data_display.js"></script>
@@ -389,6 +390,7 @@
             <div data-i18n="lonColumn">Довгота</div>
             <div data-i18n="altColumn">Висота</div>
             <div data-i18n="moveSpeedColumn">Швидкість руху км/год</div>
+            <div data-i18n="distanceColumn">Відстань (м)</div>
             <div data-i18n="oblastColumn">Область</div>
             <div data-i18n="raionColumn">Район</div>
             <div data-i18n="hromadaColumn">Громада</div>

--- a/js/data_point.js
+++ b/js/data_point.js
@@ -57,6 +57,10 @@ async function saveDataPoint() {
     const elapsed = (Date.now() - startTime) / 1000;
 
     // Обчислюємо відстань для додавання до загальної
+    let pointDistance = getDistanceToLastPoint(
+        currentGPSData.latitude,
+        currentGPSData.longitude
+    );
     if (lastSavedGPSData.latitude && lastSavedGPSData.longitude) {
         const distance = calculateDistance(
             lastSavedGPSData.latitude,
@@ -77,6 +81,7 @@ async function saveDataPoint() {
         longitude: currentGPSData.longitude,
         altitude: currentGPSData.altitude,
         gpsSpeed: currentGPSData.speed ? currentGPSData.speed * 3.6 : null,
+        distance: pointDistance,
         accuracy: currentGPSData.accuracy,
         heading: currentGPSData.heading,
         region: adminInfo.region || null,

--- a/js/point_distance.js
+++ b/js/point_distance.js
@@ -1,0 +1,15 @@
+function getDistanceToLastPoint(lat, lon) {
+    if (!lastSavedGPSData.latitude || !lastSavedGPSData.longitude) {
+        return 0;
+    }
+    const distance = calculateDistance(
+        lastSavedGPSData.latitude,
+        lastSavedGPSData.longitude,
+        lat,
+        lon
+    );
+    return distance <= 100 ? distance : 0;
+}
+
+window.getDistanceToLastPoint = getDistanceToLastPoint;
+

--- a/js/update_data_display.js
+++ b/js/update_data_display.js
@@ -18,6 +18,7 @@ function updateDataDisplay() {
                     <div>${record.longitude ? record.longitude.toFixed(6) : "N/A"}</div>
                     <div>${record.altitude ? record.altitude.toFixed(1) : "N/A"}</div>
                     <div>${record.gpsSpeed ? record.gpsSpeed.toFixed(1) : "N/A"}</div>
+                    <div>${record.distance !== undefined ? record.distance.toFixed(1) : "N/A"}</div>
                     <div>${record.region || 'N/A'}</div>
                     <div>${record.rayon || 'N/A'}</div>
                     <div>${record.hromada || 'N/A'}</div>

--- a/styles/style.css
+++ b/styles/style.css
@@ -423,7 +423,7 @@ h1 {
 
 .data-row {
   display: grid;
-  grid-template-columns: repeat(10, 1fr);
+  grid-template-columns: repeat(11, 1fr);
   gap: 10px;
   padding: 8px 0;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
@@ -627,7 +627,7 @@ h1 {
   .data-row {
     gap: 5px;
     font-size: 0.7em;
-    grid-template-columns: repeat(10, 1fr);
+    grid-template-columns: repeat(11, 1fr);
   }
 
   .data-header-row {

--- a/translations/en.js
+++ b/translations/en.js
@@ -65,6 +65,7 @@ window.i18n.en = {
   lonColumn: "Longitude",
   altColumn: "Altitude (m)",
   moveSpeedColumn: "Movement speed km/h",
+  distanceColumn: "Distance (m)",
   oblastColumn: "Oblast",
   raionColumn: "District",
   hromadaColumn: "Community",

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -65,6 +65,7 @@ window.i18n.uk = {
   lonColumn: "Довгота",
   altColumn: "Висота (м)",
   moveSpeedColumn: "Швидкість руху (км/год)",
+  distanceColumn: "Відстань (м)",
   oblastColumn: "Область",
   raionColumn: "Район",
   hromadaColumn: "Громада",


### PR DESCRIPTION
## Summary
- calculate distance between consecutive points when saving data
- store new `distance` field in records
- display distance in the latest measurements table
- translate new column header
- adjust data table styles for the additional column
- add helper module `point_distance.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887918121608329b39f268fab7cc4c0