### PR TITLE
Add distance field to KML export

### DIFF
--- a/js/download_KML.js
+++ b/js/download_KML.js
@@ -73,6 +73,7 @@ function downloadKML() {
             `Громада: ${record.hromada}<br>` +
             `Номер дороги: ${record.roadRef ?? ''}<br>` +
             `GPS Швидкість (км/год): ${record.gpsSpeed ? record.gpsSpeed.toFixed(1) : ''}<br>` +
+            `Відстань (м): ${record.distance ? record.distance.toFixed(1) : ''}<br>` +
             `Точність (м): ${record.accuracy ? record.accuracy.toFixed(1) : ''}<br>` +
             `Напрямок (°): ${record.heading ? record.heading.toFixed(1) : ''}`;
 


### PR DESCRIPTION
## Summary
- include distance (meters) in each Placemark description during KML export

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688796226fa08329ac915f865a0d620e