### PR TITLE
Display distance info in map popups

### DIFF
--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -45,19 +45,21 @@ function downloadHTML() {
 
     let getMarkerPopupContentSrc = window.getMarkerPopupContent.toString();
 
-    const speedRow =
-        "point.gpsSpeed != null ? point.gpsSpeed.toFixed(1) : na],";
-    const distanceRow =
-        "        [ensureColon(t('distanceColumn', 'Відстань (м)')), " +
-        "point.distance != null ? point.distance.toFixed(1) : na],";
-    const idx = getMarkerPopupContentSrc.indexOf(speedRow);
-    if (idx !== -1) {
-        const insertPos = idx + speedRow.length;
-        getMarkerPopupContentSrc =
-            getMarkerPopupContentSrc.slice(0, insertPos) +
-            '\n' +
-            distanceRow +
-            getMarkerPopupContentSrc.slice(insertPos);
+    if (!getMarkerPopupContentSrc.includes("distanceColumn")) {
+        const speedRow =
+            "point.gpsSpeed != null ? point.gpsSpeed.toFixed(1) : na],";
+        const distanceRow =
+            "        [ensureColon(t('distanceColumn', 'Відстань (м)')), " +
+            "point.distance != null ? point.distance.toFixed(1) : na],";
+        const idx = getMarkerPopupContentSrc.indexOf(speedRow);
+        if (idx !== -1) {
+            const insertPos = idx + speedRow.length;
+            getMarkerPopupContentSrc =
+                getMarkerPopupContentSrc.slice(0, insertPos) +
+                '\n' +
+                distanceRow +
+                getMarkerPopupContentSrc.slice(insertPos);
+        }
     }
 
     const htmlContent = `

--- a/js/map.js
+++ b/js/map.js
@@ -119,6 +119,8 @@ function getMarkerPopupContent(point) {
             point.altitude != null ? point.altitude.toFixed(1) : na],
         [ensureColon(t('moveSpeedColumn', 'Швидкість руху (км/год)')),
             point.gpsSpeed != null ? point.gpsSpeed.toFixed(1) : na],
+        [ensureColon(t('distanceColumn', 'Відстань (м)')),
+            point.distance != null ? point.distance.toFixed(1) : na],
         [ensureColon(t('gpsAccuracyLabel', 'Точність (м)')),
             point.accuracy != null ? point.accuracy.toFixed(1) : na],
         [ensureColon(t('headingLabel', 'Напрямок руху')),


### PR DESCRIPTION
## Summary
- show distance from previous point in live map popups
- adjust HTML export generation so distance row isn't duplicated

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887993d7a308329a1dfed76d9199594