### PR TITLE
Fix sticky header in data table

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -439,6 +439,9 @@ h1 {
   padding: 10px;
   border-radius: 5px;
   margin-bottom: 10px;
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 
 .records-count {
@@ -632,6 +635,9 @@ h1 {
 
   .data-header-row {
     padding: 8px;
+    position: sticky;
+    top: 0;
+    z-index: 1;
   }
 
   .settings-panel {


### PR DESCRIPTION
## Summary
- keep the table header visible when scrolling the data table

## Testing
- `npx prettier -w styles/style.css` *(fails: not found)*
- `npm test` *(fails: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887afd406848329a351b17008dac4cd