### PR TITLE
Display road length in road stats

### DIFF
--- a/js/update_road_stats.js
+++ b/js/update_road_stats.js
@@ -65,8 +65,10 @@ function updateRoadStats() {
         const zl = s.length ? Math.round((zKm / s.length) * 100) : 0;
         const ul = s.length ? Math.round((uKm / s.length) * 100) : 0;
         const al = s.length ? Math.round((aKm / s.length) * 100) : 0;
+        const lenUnit = currentLang === 'uk' ? 'км' : 'km';
+        const lenStr = s.length ? `${s.length.toFixed(1)} ${lenUnit}` : '-';
         rows.push(
-            `<div class="info-row"><span>${road}</span><span>${s.total}</span></div>` +
+            `<div class="info-row"><span>${road}</span><span>${s.total} (${lenStr})</span></div>` +
             `<div class="info-row"><span>Тестів (% від загальної кількості)</span></div>` +
             `<div class="info-row"><span>${t('zeroSpeedLabel', '0 Мбіт/с:')}</span><span>${s.zero} (${zp}%)</span></div>` +
             `<div class="info-row"><span>${t('upTo2SpeedLabel', 'До 2 Мбіт/с:')}</span><span>${s.upto2} (${up}%)</span></div>` +


### PR DESCRIPTION
## Summary
- show road length in parentheses next to test count per road

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6887c7588610832981f883c5ade1099e