### PR TITLE
Stop map center when popup open

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -151,11 +151,15 @@ function addMapMarker(point, centerOnAdd = true) {
         marker.addTo(map);
     }
     if (typeof marker.bindPopup === 'function') {
-        marker.bindPopup(getMarkerPopupContent(point));
+        marker.bindPopup(getMarkerPopupContent(point), { autoPan: false });
     }
     mapMarkers.push(marker);
     if (centerOnAdd) {
-        map.setView([point.latitude, point.longitude], map.getZoom());
+        const openPopup =
+            typeof map.getPopup === 'function' ? map.getPopup() : map._popup;
+        if (!(openPopup && map.hasLayer(openPopup))) {
+            map.setView([point.latitude, point.longitude], map.getZoom());
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure map popups are stable
- disable map auto-pan on popup bind
- prevent auto-centering while a popup is open

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688a5114f36083298223e8ad91b99b3c