### PR TITLE
Enable voice alerts when sub-options selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A minimal browser-based network speed test. The app runs entirely in the browser
 - Optional upload test and ping statistics
 - Ability to select a test server
 - GPS tracking with map view and recorded route
-- Sound and voice alerts
+- Sound and voice alerts (community or road announcements automatically enable voice alerts)
 - Works offline and can be installed as a PWA
 - Stores measurements locally using IndexedDB
 - Language selection

--- a/js/settings.js
+++ b/js/settings.js
@@ -59,6 +59,10 @@ function saveSettings() {
     settings.voiceAlerts = document.getElementById("voiceAlerts").checked;
     settings.voiceHromadaChange = document.getElementById("voiceHromadaChange").checked;
     settings.voiceRoadChange = document.getElementById("voiceRoadChange").checked;
+    if ((settings.voiceHromadaChange || settings.voiceRoadChange) && !settings.voiceAlerts) {
+        settings.voiceAlerts = true;
+        document.getElementById("voiceAlerts").checked = true;
+    }
     settings.showHromady = document.getElementById("showHromady").checked;
     settings.showInternationalRoads = document.getElementById("showInternationalRoads").checked;
     settings.showNationalRoads = document.getElementById("showNationalRoads").checked;


### PR DESCRIPTION
## Summary
- toggle global voice alerts on automatically when either community or road announcements are checked
- update README to document this behaviour

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688a53ef98d083298b78f5361fdd9ebf