### PR TITLE
Remove data interval settings from UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,21 +120,6 @@
     <div class="settings-panel" id="settingsPanel">
       <h3 class="mb-20" data-i18n="settingsTitle">Налаштування</h3>
       <div class="setting-group">
-        <label class="setting-label" for="saveInterval" data-i18n="saveIntervalLabel">Інтервал збереження даних
-          (секунди):</label>
-        <input type="number" class="setting-input" id="saveInterval" value="1" min="1" max="60" />
-      </div>
-      <div class="setting-group">
-        <label class="setting-label" for="gpsDistance" data-i18n="gpsDistanceLabel">Мінімальна відстань для збереження
-          GPS (метри):</label>
-        <input type="number" class="setting-input" id="gpsDistance" value="10" min="0" max="100" />
-      </div>
-      <div class="setting-group">
-        <label class="setting-label" for="speedThreshold" data-i18n="speedThresholdLabel">Поріг швидкості для сповіщення
-          (Мбіт/с):</label>
-        <input type="number" class="setting-input" id="speedThreshold" value="5" min="0" max="1000" />
-      </div>
-      <div class="setting-group">
         <div class="checkbox-group">
           <input type="checkbox" id="soundAlerts" />
           <label class="setting-label" for="soundAlerts" data-i18n="soundAlertsLabel">Звукові сповіщення падіння швидкості завантаження</label>

--- a/js/settings.js
+++ b/js/settings.js
@@ -16,45 +16,7 @@ function loadSettingsFromStorage() {
     }
 }
 
-function clampNumber(value, min, max, def) {
-    const num = parseFloat(value);
-    if (isNaN(num)) return { value: def, error: true };
-    if (num < min) return { value: min, error: true };
-    if (num > max) return { value: max, error: true };
-    return { value: num, error: false };
-}
-
 function saveSettings() {
-    let hasError = false;
-    let result = clampNumber(
-        document.getElementById("saveInterval").value,
-        1,
-        60,
-        DEFAULT_SAVE_INTERVAL
-    );
-    settings.saveInterval = result.value;
-    document.getElementById("saveInterval").value = settings.saveInterval;
-    hasError = hasError || result.error;
-
-    result = clampNumber(
-        document.getElementById("gpsDistance").value,
-        0,
-        100,
-        10
-    );
-    settings.gpsDistance = result.value;
-    document.getElementById("gpsDistance").value = settings.gpsDistance;
-    hasError = hasError || result.error;
-
-    result = clampNumber(
-        document.getElementById("speedThreshold").value,
-        0,
-        1000,
-        5
-    );
-    settings.speedThreshold = result.value;
-    document.getElementById("speedThreshold").value = settings.speedThreshold;
-    hasError = hasError || result.error;
     settings.soundAlerts = document.getElementById("soundAlerts").checked;
     settings.voiceAlerts = document.getElementById("voiceAlerts").checked;
     settings.voiceHromadaChange = document.getElementById("voiceHromadaChange").checked;
@@ -89,19 +51,11 @@ function saveSettings() {
         updateRoadLayers();
     }
 
-    if (hasError) {
-        showNotification(t('settingsInvalid', 'Некоректні значення!'));
-    } else {
-        showNotification(t('settingsSaved', 'Налаштування збережено!'));
-    }
+    showNotification(t('settingsSaved', 'Налаштування збережено!'));
     toggleSettings();
 }
 
 function loadSettings() {
-    document.getElementById("saveInterval").value = settings.saveInterval;
-    document.getElementById("gpsDistance").value = settings.gpsDistance;
-    document.getElementById("speedThreshold").value =
-        settings.speedThreshold;
     document.getElementById("soundAlerts").checked = settings.soundAlerts;
     document.getElementById("voiceAlerts").checked = settings.voiceAlerts;
     document.getElementById("voiceHromadaChange").checked = settings.voiceHromadaChange;


### PR DESCRIPTION
## Summary
- remove save interval, GPS distance and speed threshold inputs from **index.html**
- clean up references in `settings.js` so those values are only taken from `config.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a58dab4fc8329abb2fb9b61bca313