### PR TITLE
Add voice change section heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,7 @@
             <label class="setting-label" for="voiceAlerts" data-i18n="voiceAlertsLabel">Голосові сповіщення падіння швидкості завантаження</label>
           </div>
         </div>
+        <h4 class="mb-10" data-i18n="voiceChangeTitle">Озвучувати</h4>
         <div class="setting-group">
           <div class="checkbox-group">
             <input type="checkbox" id="voiceHromadaChange" />

--- a/translations/en.js
+++ b/translations/en.js
@@ -14,6 +14,7 @@ window.i18n.en = {
   speedThresholdLabel: "Speed threshold for alert (Mbps):",
   soundAlertsLabel: "Sound alerts",
   voiceAlertsLabel: "Voice alerts",
+  voiceChangeTitle: "Announce",
   voiceHromadaChangeLabel: "Announce community change",
   voiceRoadChangeLabel: "Announce road change",
   showHromadyLabel: "Show community boundaries",

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -14,6 +14,7 @@ window.i18n.uk = {
   speedThresholdLabel: "Поріг швидкості для сповіщення (Мбіт/с):",
   soundAlertsLabel: "Звукові сповіщення",
   voiceAlertsLabel: "Голосові сповіщення",
+  voiceChangeTitle: "Озвучувати",
   voiceHromadaChangeLabel: "Озвучувати зміну громади",
   voiceRoadChangeLabel: "Озвучувати зміну дороги",
   showHromadyLabel: "Відображати межі громад",


### PR DESCRIPTION
## Summary
- group voice change options under a new heading
- provide i18n entries for the heading in English and Ukrainian translations

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a5e31e3108329a2dbdc4e119d703d