### PR TITLE
Fix settings panel state

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -1,6 +1,13 @@
 function toggleSettings() {
     const panel = document.getElementById("settingsPanel");
+    const shouldOpen = !panel.classList.contains("active");
     panel.classList.toggle("active");
+
+    // Reload settings when panel is opened to show latest state
+    if (shouldOpen) {
+        loadSettingsFromStorage();
+        loadSettings();
+    }
 }
 
 const SETTINGS_STORAGE_KEY = 'settings';


### PR DESCRIPTION
## Summary
- reload settings from storage whenever opening the settings panel so current values are shown

## Testing
- `npm test` *(fails: could not find package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c50461be08329a8c43bfe936b292e