### PR TITLE
Display total distance in admin stats

### DIFF
--- a/js/update_admin_stats.js
+++ b/js/update_admin_stats.js
@@ -91,10 +91,17 @@ function updateAdminStats() {
             `<div class="info-row" style="--indent:${indent}px"><span>${t('above2SpeedLabel', 'Більше 2 Мбіт/с:')}</span><span>${(obj.distAbove2 / 1000).toFixed(1)} ${unit}</span></div>`
         );
     };
-    const statsRows = (obj, indent) =>
-        countRows(obj, indent) +
-        `<div class="info-row"><span>Відстань (км)</span></div>` +
-        distRows(obj, indent);
+    const statsRows = (obj, indent) => {
+        const totalKm = (
+            (obj.distZero + obj.distUpto2 + obj.distAbove2) /
+            1000
+        ).toFixed(1);
+        return (
+            countRows(obj, indent) +
+            `<div class="info-row"><span>Відстань (км)</span><span>${totalKm}</span></div>` +
+            distRows(obj, indent)
+        );
+    };
 
     for (const regName of regions) {
         const reg = stats[regName];


### PR DESCRIPTION
## Summary
- show total travelled distance for each administrative unit in `updateAdminStats`

## Testing
- `npm test` *(fails: could not find `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c5be7022c8329a188d76fb1c2bb24