### PR TITLE
Fix admin stats distance row indentation

### DIFF
--- a/js/update_admin_stats.js
+++ b/js/update_admin_stats.js
@@ -98,7 +98,7 @@ function updateAdminStats() {
         ).toFixed(1);
         return (
             countRows(obj, indent) +
-            `<div class="info-row"><span>Відстань (км)</span><span>${totalKm}</span></div>` +
+            `<div class="info-row" style="--indent:${indent}px"><span>Відстань (км)</span><span>${totalKm}</span></div>` +
             distRows(obj, indent)
         );
     };


### PR DESCRIPTION
## Summary
- add missing indent style on distance row in admin stats

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c8105fad48329afb83e2d2eb9a109