### PR TITLE
Fix independent voice settings

### DIFF
--- a/js/audio_notification.js
+++ b/js/audio_notification.js
@@ -43,7 +43,7 @@ function playBeep(frequency = BEEP_FREQUENCY, duration = BEEP_DURATION) {
 }
 
 function speak(text) {
-    if (!settings.voiceAlerts || !speechSynthesis) return;
+    if (!speechSynthesis) return;
 
     const utterance = new SpeechSynthesisUtterance(text);
     utterance.lang = "uk-UA";

--- a/js/hromada_change_announcer.js
+++ b/js/hromada_change_announcer.js
@@ -7,7 +7,7 @@ function announceAdminChange(info) {
         return;
     }
 
-    if (settings.voiceHromadaChange && settings.voiceAlerts && lastAdminUnit.hromada) {
+    if (settings.voiceHromadaChange && lastAdminUnit.hromada) {
         if (
             lastAdminUnit.hromada !== info.hromada ||
             lastAdminUnit.rayon !== info.rayon ||

--- a/js/road_change_announcer.js
+++ b/js/road_change_announcer.js
@@ -11,7 +11,7 @@ function announceRoadChange(road) {
     const currentName = road.official_name || road['name:uk'] || road.name || null;
     const currentNetwork = road.network || null;
 
-    if (settings.voiceRoadChange && settings.voiceAlerts) {
+    if (settings.voiceRoadChange) {
         if (
             !lastRoad.ref ||
             lastRoad.ref !== currentRef ||

--- a/js/settings.js
+++ b/js/settings.js
@@ -28,10 +28,6 @@ function saveSettings() {
     settings.voiceAlerts = document.getElementById("voiceAlerts").checked;
     settings.voiceHromadaChange = document.getElementById("voiceHromadaChange").checked;
     settings.voiceRoadChange = document.getElementById("voiceRoadChange").checked;
-    if ((settings.voiceHromadaChange || settings.voiceRoadChange) && !settings.voiceAlerts) {
-        settings.voiceAlerts = true;
-        document.getElementById("voiceAlerts").checked = true;
-    }
     settings.showHromady = document.getElementById("showHromady").checked;
     settings.showInternationalRoads = document.getElementById("showInternationalRoads").checked;
     settings.showNationalRoads = document.getElementById("showNationalRoads").checked;

--- a/js/speed_test.js
+++ b/js/speed_test.js
@@ -173,10 +173,12 @@ async function runTest() {
         `(${consecutiveErrors}/${MAX_CONSECUTIVE_ERRORS})`
       );
       playBeep(300, 500);
-      if (consecutiveErrors === 1) {
-        showNotification(t('alertConnectionLost', "Втрачено з'єднання!"));
-        speak("Втрачено з'єднання з інтернетом");
-      }
+        if (consecutiveErrors === 1) {
+          showNotification(t('alertConnectionLost', "Втрачено з'єднання!"));
+          if (settings.voiceAlerts) {
+            speak("Втрачено з'єднання з інтернетом");
+          }
+        }
 
       await waitForReconnect();
       if (!testActive) break;


### PR DESCRIPTION
## Summary
- do not auto-enable voice alerts when selecting community or road changes
- allow announcements without the general voice alert setting
- gate connection loss speech by user setting

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688cb35319288329b72f0817d79b8ef6