### PR TITLE
Handle missing notification element in audio notifications

### DIFF
--- a/js/audio_notification.js
+++ b/js/audio_notification.js
@@ -4,6 +4,10 @@ let speechSynthesis = window.speechSynthesis;
 
 function showNotification(message, duration = NOTIFICATION_DURATION) {
     const notification = document.getElementById("notification");
+    if (!notification) {
+        console.warn("Notification element not found");
+        return;
+    }
     notification.textContent = message;
     notification.style.display = "block";
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- Guard `showNotification` against missing notification element
- Log a warning and exit early when `#notification` is absent

## Testing
- `npm test` *(fails: ENOENT no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68938b90d2708329a07e9c3919a40ed5