### PR TITLE
Handle missing recordsCount element

### DIFF
--- a/js/update_database_info.js
+++ b/js/update_database_info.js
@@ -24,7 +24,12 @@ function initStorageQuota() {
 }
 
 function updateDatabaseInfo() {
-    document.getElementById("recordsCount").textContent = speedData.length;
+    const recordsCountEl = document.getElementById("recordsCount");
+    if (recordsCountEl) {
+        recordsCountEl.textContent = speedData.length;
+    } else {
+        console.warn("recordsCount element not found");
+    }
     const recordsEl = document.getElementById("dbRecordsCount");
     const sizeEl = document.getElementById("dbSize");
 


### PR DESCRIPTION
## Summary
- add a null check around the `recordsCount` element
- warn if the element is missing when updating database info

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68938bda04388329a487557147349d19