### PR TITLE
feat: request wake lock on test start

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,6 @@
 
   <script defer src="js/config.js"></script>
   <script defer src="js/lang.js"></script>
-  <script defer src="js/wake_lock.js"></script>
   <script defer src="js/storage.js"></script>
   <script defer src="js/detect_ISP.js"></script>
   <script defer src="js/format_seconds.js"></script>
@@ -66,7 +65,7 @@
   <script defer src="js/download_chart.js"></script>
   <script defer src="js/clear_data.js"></script>
   <script defer src="js/update_UI.js"></script>
-  <script defer src="js/speed_test.js"></script>
+  <script type="module" src="js/speed_test.js"></script>
   <script defer src="js/toggle_theme.js"></script>
   <script defer src="js/toggle_fullscreen.js"></script>
   <script defer src="js/refresh_page.js"></script>

--- a/js/speed_test.js
+++ b/js/speed_test.js
@@ -1,3 +1,5 @@
+import { requestWakeLock } from './wake_lock.js';
+
 function resetTestState() {
     testInProgress = false;
     pendingRun = false;
@@ -269,6 +271,7 @@ async function toggleTest() {
         testActive = true;
         document.getElementById("startBtn").textContent = t('stopTest', 'Зупинити тест');
 
+        await requestWakeLock();
         await detectISP();
 
         addLog("Старт тесту");

--- a/js/wake_lock.js
+++ b/js/wake_lock.js
@@ -1,7 +1,7 @@
 // Wake Lock
 let wakeLock = null;
 
-async function requestWakeLock() {
+export async function requestWakeLock() {
     try {
         wakeLock = await navigator.wakeLock.request('screen');
         wakeLock.addEventListener('release', async () => {
@@ -21,3 +21,7 @@ document.addEventListener('visibilitychange', async () => {
         await requestWakeLock();
     }
 });
+
+if (typeof window !== 'undefined') {
+    window.requestWakeLock = requestWakeLock;
+}


### PR DESCRIPTION
## Summary
- export and expose `requestWakeLock` so other modules can acquire the screen wake lock
- call `requestWakeLock` when beginning a speed test
- load `speed_test.js` as a module to support imports

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68938bec3c44832997463a1a5e9a87fd