### PR TITLE
feat: track download delta

### DIFF
--- a/js/data_point.js
+++ b/js/data_point.js
@@ -71,11 +71,14 @@ async function saveDataPoint() {
         totalDistance += distance;
     }
 
+    const downloadedDelta =
+        (totalBytes - lastSavedBytes) / (1024 * 1024);
+
     const dataPoint = {
         timestamp: now.toLocaleTimeString(),
         fullTimestamp: now,
         speed: currentSpeedMbps,
-        downloaded: totalBytes / (1024 * 1024),
+        downloadedDelta: downloadedDelta,
         elapsed: Math.floor(elapsed),
         latitude: currentGPSData.latitude,
         longitude: currentGPSData.longitude,
@@ -91,6 +94,7 @@ async function saveDataPoint() {
     };
 
     speedData.push(dataPoint);
+    lastSavedBytes = totalBytes;
     saveSpeedDataToStorage();
     addMapMarker(dataPoint);
 

--- a/js/download_CSV.js
+++ b/js/download_CSV.js
@@ -66,7 +66,7 @@ function downloadCSV() {
                     `${record.roadRef || ""};` +
                     `${operator};` +
                     `${record.speed.toFixed(2)};` +
-                    `${record.downloaded.toFixed(2)};` +
+                    `${record.downloadedDelta.toFixed(2)};` +
                     `${record.elapsed || ""};` +
                     `${record.latitude || ""};` +
                     `${record.longitude || ""};` +

--- a/js/download_KML.js
+++ b/js/download_KML.js
@@ -63,7 +63,7 @@ function downloadKML() {
             `Час: ${timeStr}<br>` +
             `Оператор: ${operator}<br>` +
             `Швидкість (Мбіт/с): ${record.speed.toFixed(2)}<br>` +
-            `Завантажено (МБ): ${record.downloaded.toFixed(2)}<br>` +
+            `Завантажено (МБ): ${record.downloadedDelta.toFixed(2)}<br>` +
             `Тривалість (с): ${record.elapsed ?? ''}<br>` +
             `Широта: ${record.latitude}<br>` +
             `Довгота: ${record.longitude}<br>` +


### PR DESCRIPTION
## Summary
- measure downloaded data since last save and store as `downloadedDelta`
- update export tools to use new `downloadedDelta` field

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689399e0c3e8832981e31990f697719c