### PR TITLE
fix: reset lastSavedBytes on test run

### DIFF
--- a/js/speed_test.js
+++ b/js/speed_test.js
@@ -144,6 +144,7 @@ async function runTest() {
   pendingRun = false;
   startTime = Date.now();
   prevBytes = totalBytes = 0;
+  lastSavedBytes = 0;
   consecutiveErrors = 0;
   // Запускаємо оновлення UI що секунду
   updateInterval = setInterval(updateUI, UI_UPDATE_INTERVAL);


### PR DESCRIPTION
## Summary
- ensure lastSavedBytes resets alongside byte counters when starting a test

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68939afca2d4832989a1f1e8b0cf0ac9