### PR TITLE
Reset byte counters when clearing data

### DIFF
--- a/js/clear_data.js
+++ b/js/clear_data.js
@@ -3,6 +3,8 @@ function clearData() {
 
     if (confirm(t('clearDataConfirm', 'Ви впевнені, що хочете очистити всі дані?'))) {
         speedData = [];
+        lastSavedBytes = 0;
+        totalBytes = 0;
         saveSpeedDataToStorage();
         chartData = [];
         lastSavedGPSData = { latitude: null, longitude: null };


### PR DESCRIPTION
## Summary
- Reset lastSavedBytes and totalBytes to zero when clearing speed data so the UI counters restart from zero.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68939bca606483299b3923cdbcd0c827