### PR TITLE
feat: add cumulative download amount to CSV

### DIFF
--- a/js/download_CSV.js
+++ b/js/download_CSV.js
@@ -24,7 +24,7 @@ function downloadCSV() {
         "Дорога;" +
         "Оператор;" +
         "Швидкість (Мбіт/с);" +
-        "Завантажено (МБ);" +
+        "Сумарно завантажено (МБ);" +
         "Тривалість (с);" +
         "Широта;" +
         "Довгота;" +
@@ -34,6 +34,7 @@ function downloadCSV() {
         "Точність (м);" +
         "Напрямок (°)\n";
 
+    let cumulative = 0;
     const csvContent =
         headers +
         speedData
@@ -66,7 +67,7 @@ function downloadCSV() {
                     `${record.roadRef || ""};` +
                     `${operator};` +
                     `${record.speed.toFixed(2)};` +
-                    `${record.downloadedDelta.toFixed(2)};` +
+                    `${(cumulative += record.downloadedDelta).toFixed(2)};` +
                     `${record.elapsed || ""};` +
                     `${record.latitude || ""};` +
                     `${record.longitude || ""};` +


### PR DESCRIPTION
## Summary
- track cumulative downloaded amount when exporting CSV
- label CSV column as total downloaded

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68939c8da770832982a0e0cefffb69bd