### PR TITLE
Refine GPS stop condition

### DIFF
--- a/js/GPS.js
+++ b/js/GPS.js
@@ -42,7 +42,7 @@ function initGPS() {
 }
 
 function stopGPS() {
-    if (gpsWatchId) {
+    if (gpsWatchId !== null) {
         navigator.geolocation.clearWatch(gpsWatchId);
         gpsWatchId = null;
         const statusEl = document.getElementById("gpsStatus");


### PR DESCRIPTION
## Summary
- Ensure GPS watcher is only cleared when watch ID exists
- Reset `gpsWatchId` to `null` after stopping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893a2115ed48329b30af6477e329055