### PR TITLE
Guard against duplicate GPS watchers

### DIFF
--- a/js/GPS.js
+++ b/js/GPS.js
@@ -5,6 +5,10 @@ function initGPS() {
         return;
     }
 
+    if (gpsWatchId !== null) {
+        stopGPS();
+    }
+
     const options = {
         enableHighAccuracy: true,
         timeout: GPS_TIMEOUT,


### PR DESCRIPTION
## Summary
- Stop an existing GPS watch before starting a new one in `initGPS`

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893a2fe9b748329967eee1c4a01b896