### PR TITLE
Await and handle hromady data loading

### DIFF
--- a/js/add_event_listener.js
+++ b/js/add_event_listener.js
@@ -2,7 +2,11 @@
 window.addEventListener("DOMContentLoaded", async () => {
     initStorageQuota();
     initLanguage();
-    loadHromadyData();
+    try {
+        await loadHromadyData();
+    } catch (err) {
+        console.error('Failed to load hromady data', err);
+    }
     loadTheme();
     loadSettingsFromStorage();
     await loadSpeedDataFromStorage();


### PR DESCRIPTION
## Summary
- await `loadHromadyData` inside `DOMContentLoaded` handler
- log failures loading hromady data so issues surface clearly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893a6b7f4a4832997a0abe1b1a7c464