### PR TITLE
feat: handle speed data load failures

### DIFF
--- a/js/add_event_listener.js
+++ b/js/add_event_listener.js
@@ -9,7 +9,11 @@ window.addEventListener("DOMContentLoaded", async () => {
     }
     loadTheme();
     loadSettingsFromStorage();
-    await loadSpeedDataFromStorage();
+    try {
+        await loadSpeedDataFromStorage();
+    } catch (err) {
+        console.error('Failed to load speed data from storage', err);
+    }
     initChart();
     loadSettings();
     updateGPSInfo();


### PR DESCRIPTION
## Summary
- handle errors when loading speed data from storage by wrapping in try/catch

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893a799e5808329bb4d3a812a22a79a