### PR TITLE
Safely check settings before playing audio beep

### DIFF
--- a/js/audio_notification.js
+++ b/js/audio_notification.js
@@ -16,7 +16,7 @@ function showNotification(message, duration = NOTIFICATION_DURATION) {
 }
 
 function playBeep(frequency = BEEP_FREQUENCY, duration = BEEP_DURATION) {
-    if (!settings.soundAlerts) return;
+    if (!window.settings || !window.settings.soundAlerts) return;
 
     try {
         if (!audioContext) {


### PR DESCRIPTION
## Summary
- avoid referencing undefined settings by verifying `window.settings` before playing audio beep

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6893aa10cd2c8329ad4eb08ba64808c6