### PR TITLE
Cancel ongoing speech before new utterance

### DIFF
--- a/js/audio_notification.js
+++ b/js/audio_notification.js
@@ -48,6 +48,7 @@ function playBeep(frequency = BEEP_FREQUENCY, duration = BEEP_DURATION) {
 
 function speak(text) {
     if (!speechSynthesis) return;
+    speechSynthesis.cancel();
 
     const utterance = new SpeechSynthesisUtterance(text);
     utterance.lang = "uk-UA";


### PR DESCRIPTION
## Summary
- Cancel any existing speech before creating a new SpeechSynthesisUtterance in `speak`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893ab21e4f88329854e2520d4a09d43