### PR TITLE
Handle missing speech synthesis support

### DIFF
--- a/js/audio_notification.js
+++ b/js/audio_notification.js
@@ -49,6 +49,7 @@ function playBeep(frequency = BEEP_FREQUENCY, duration = BEEP_DURATION) {
 function speak(text) {
     if (!speechSynthesis) return;
     speechSynthesis.cancel();
+    if (typeof SpeechSynthesisUtterance === 'undefined') return;
 
     const utterance = new SpeechSynthesisUtterance(text);
     utterance.lang = "uk-UA";


### PR DESCRIPTION
## Summary
- ensure audio notifications gracefully skip speech when `SpeechSynthesisUtterance` is unavailable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893abab2ecc832983b81c6c31045ca2