### PR TITLE
Resume audio context before playing beep

### DIFF
--- a/js/audio_notification.js
+++ b/js/audio_notification.js
@@ -15,13 +15,17 @@ function showNotification(message, duration = NOTIFICATION_DURATION) {
     }, duration);
 }
 
-function playBeep(frequency = BEEP_FREQUENCY, duration = BEEP_DURATION) {
+async function playBeep(frequency = BEEP_FREQUENCY, duration = BEEP_DURATION) {
     if (!window.settings || !window.settings.soundAlerts) return;
 
     try {
         if (!audioContext) {
             audioContext = new (window.AudioContext ||
                 window.webkitAudioContext)();
+        }
+
+        if (audioContext.state === "suspended") {
+            await audioContext.resume();
         }
 
         const oscillator = audioContext.createOscillator();


### PR DESCRIPTION
## Summary
- Ensure audio context resumes from `suspended` state before playing oscillator

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893ac52af608329a0317b4806d98028