### PR TITLE
Define chart variables to avoid implicit globals

### DIFF
--- a/js/chart.js
+++ b/js/chart.js
@@ -1,3 +1,8 @@
+/* global currentSpeedMbps, maxDataPoints */
+
+let speedChart;
+const chartData = [];
+
 function initChart() {
     const ctx = document.getElementById("speedChart").getContext("2d");
     speedChart = new Chart(ctx, {


### PR DESCRIPTION
## Summary
- add explicit `speedChart` and `chartData` declarations
- document usage of global `currentSpeedMbps` and `maxDataPoints` in chart logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893ae24ff6c8329a62b1ca88adc2f8f