### PR TITLE
Add canvas existence check before chart initialization

### DIFF
--- a/js/chart.js
+++ b/js/chart.js
@@ -4,7 +4,9 @@ let speedChart;
 const chartData = [];
 
 function initChart() {
-    const ctx = document.getElementById("speedChart").getContext("2d");
+    const canvas = document.getElementById("speedChart");
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
     speedChart = new Chart(ctx, {
         type: "line",
         data: {


### PR DESCRIPTION
## Summary
- Avoid errors when initializing speed chart by checking for missing canvas element

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893af7b5f1c832986933a193c6b2495