### PR TITLE
refactor: reuse text color in chart initialization

### DIFF
--- a/js/chart.js
+++ b/js/chart.js
@@ -7,6 +7,9 @@ function initChart() {
     const canvas = document.getElementById("speedChart");
     if (!canvas) return;
     const ctx = canvas.getContext("2d");
+    const textColor = getComputedStyle(
+        document.documentElement
+    ).getPropertyValue("--text-color");
     speedChart = new Chart(ctx, {
         type: "line",
         data: {
@@ -31,18 +34,14 @@ function initChart() {
             plugins: {
                 legend: {
                     labels: {
-                        color: getComputedStyle(
-                            document.documentElement
-                        ).getPropertyValue("--text-color"),
+                        color: textColor,
                     },
                 },
             },
             scales: {
                 x: {
                     ticks: {
-                        color: getComputedStyle(
-                            document.documentElement
-                        ).getPropertyValue("--text-color"),
+                        color: textColor,
                         maxTicksLimit: 10,
                     },
                     grid: {
@@ -52,9 +51,7 @@ function initChart() {
                 y: {
                     beginAtZero: true,
                     ticks: {
-                        color: getComputedStyle(
-                            document.documentElement
-                        ).getPropertyValue("--text-color"),
+                        color: textColor,
                     },
                     grid: {
                         color: "rgba(255,255,255,0.1)",


### PR DESCRIPTION
## Summary
- cache computed CSS text color once when initializing the speed chart
- reuse cached text color for legend and axis tick styling

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/gonettest/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6893b0a8e9988329b5b2e1f971bedf41