### PR TITLE
Check chart data existence before clearing

### DIFF
--- a/js/clear_data.js
+++ b/js/clear_data.js
@@ -12,9 +12,11 @@ function clearData() {
         speedStats = { min: Infinity, max: 0, sum: 0, count: 0 };
 
         if (speedChart) {
-            speedChart.data.labels = [];
-            speedChart.data.datasets[0].data = [];
-            speedChart.update();
+            if (speedChart.data && speedChart.data.datasets && speedChart.data.datasets[0]) {
+                speedChart.data.labels = [];
+                speedChart.data.datasets[0].data = [];
+                speedChart.update();
+            }
         }
 
         if (typeof map !== 'undefined' && map) {


### PR DESCRIPTION
## Summary
- Avoid errors when clearing charts by verifying `speedChart.data.datasets[0]` exists

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893b2dc9c8c83299c32fe17338b7fcb