### PR TITLE
fix: remove extra space from min speed display

### DIFF
--- a/js/clear_data.js
+++ b/js/clear_data.js
@@ -43,7 +43,7 @@ function clearData() {
         if (maxSpeed) maxSpeed.textContent = "0.00";
 
         const minSpeed = document.getElementById("minSpeed");
-        if (minSpeed) minSpeed.textContent = "0.00 ";
+        if (minSpeed) minSpeed.textContent = "0.00";
 
         const totalDistanceInfo = document.getElementById("totalDistanceInfo");
         if (totalDistanceInfo) totalDistanceInfo.textContent = "0.00";


### PR DESCRIPTION
## Summary
- remove stray space from `minSpeed` element text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893b385b3588329a6290781336668d8