### PR TITLE
fix: expose chart initialization globally

### DIFF
--- a/js/add_event_listener.js
+++ b/js/add_event_listener.js
@@ -14,7 +14,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     } catch (err) {
         console.error('Failed to load speed data from storage', err);
     }
-    initChart();
+    window.initChart();
     loadSettings();
     updateGPSInfo();
     requestWakeLock();

--- a/js/chart.js
+++ b/js/chart.js
@@ -1,4 +1,12 @@
-/* global currentSpeedMbps, maxDataPoints, speedChart, chartData */
+/* global currentSpeedMbps, maxDataPoints */
+
+// Ensure global chart variables exist
+if (typeof window.speedChart === "undefined") {
+    window.speedChart = null;
+}
+if (typeof window.chartData === "undefined") {
+    window.chartData = [];
+}
 
 function initChart() {
     const canvas = document.getElementById("speedChart");
@@ -61,6 +69,8 @@ function initChart() {
         },
     });
 }
+// Expose initChart globally so other scripts can invoke it
+window.initChart = initChart;
 
 function updateChart() {
     if (!speedChart) return;
@@ -81,4 +91,6 @@ function updateChart() {
     speedChart.data.datasets[0].data = chartData.map((d) => d.speed);
     speedChart.update("none");
 }
+// Expose updateChart for modules that call it
+window.updateChart = updateChart;
 


### PR DESCRIPTION
## Summary
- ensure `speedChart` and `chartData` globals exist and expose `initChart` / `updateChart` on `window`
- invoke chart initialization through `window.initChart` in event listener

## Testing
- `node - <<'NODE'
// Setup stub environment
const window = global;
window.addEventListener = () => {};
window.document = {
  getElementById: () => ({getContext: () => ({})}),
  documentElement: {},
  addEventListener: () => {}
};
window.getComputedStyle = () => ({getPropertyValue: () => '#000'});
window.t = (k, d) => d;
window.Chart = function(ctx, cfg){ this.data = cfg.data; this.update = () => {}; this.resize = () => {}; };
// expose
globalThis.window = window;
// load scripts
require('./js/chart.js');
require('./js/add_event_listener.js');
// call initChart to simulate DOMContentLoaded
window.initChart();
console.log('speedChart defined:', typeof window.speedChart);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6893b67b0bf483299d88c16bf101a76e