### PR TITLE
Fix missing semicolons in configuration

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -111,10 +111,10 @@ let speedStats = {
     count: 0,
 };
 
-let operator = ''
+let operator = '';
 
  let operators = {
     'AS21497 PrJSC VF UKRAINE': 'Vodafone',
     'AS15895 "Kyivstar" PJSC': 'Kyivstar',
     'AS34058 Limited Liability Company "lifecell"': 'Lifecell'
-}
+};


### PR DESCRIPTION
## Summary
- Add missing semicolon after operator variable
- Terminate operators object with semicolon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893b7e3231c8329a7884354dd955de3