### PR TITLE
Fix operators declaration formatting

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -113,7 +113,7 @@ let speedStats = {
 
 let operator = '';
 
- let operators = {
+let operators = {
     'AS21497 PrJSC VF UKRAINE': 'Vodafone',
     'AS15895 "Kyivstar" PJSC': 'Kyivstar',
     'AS34058 Limited Liability Company "lifecell"': 'Lifecell'


### PR DESCRIPTION
## Summary
- remove stray leading space before operators dictionary declaration

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893b8624e4883298cc1ce9a763e9072