### PR TITLE
Use const for operators configuration

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -113,7 +113,7 @@ let speedStats = {
 
 let operator = '';
 
-let operators = {
+const operators = {
     'AS21497 PrJSC VF UKRAINE': 'Vodafone',
     'AS15895 "Kyivstar" PJSC': 'Kyivstar',
     'AS34058 Limited Liability Company "lifecell"': 'Lifecell'


### PR DESCRIPTION
## Summary
- use `const` for operators mapping in `config.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893b92fcfcc8329b2dc74781f116b8e