### PR TITLE
Add null check for lastSaveInfo element in data point save

### DIFF
--- a/js/data_point.js
+++ b/js/data_point.js
@@ -104,10 +104,16 @@ async function saveDataPoint() {
     };
 
     const lastSaveEl = document.getElementById("lastSaveInfo");
-    lastSaveEl.textContent = now.toLocaleTimeString();
-    lastSaveEl.removeAttribute('data-i18n');
-    lastSaveEl.classList.remove('status-warning', 'status-success', 'status-accent');
-    lastSaveEl.classList.add('status-accent');
+    if (lastSaveEl) {
+        lastSaveEl.textContent = now.toLocaleTimeString();
+        lastSaveEl.removeAttribute('data-i18n');
+        lastSaveEl.classList.remove(
+            'status-warning',
+            'status-success',
+            'status-accent'
+        );
+        lastSaveEl.classList.add('status-accent');
+    }
 
     updateDataDisplay();
     updateDatabaseInfo();


### PR DESCRIPTION
## Summary
- prevent null dereference when updating `lastSaveInfo` by checking if the element exists first

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893ba2a67bc832985936f4ad25e5854