### PR TITLE
Load ISP detection on DOM ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
   <script defer src="js/config.js"></script>
   <script defer src="js/lang.js"></script>
   <script defer src="js/storage.js"></script>
-  <script defer src="js/detect_ISP.js"></script>
+  <script src="js/detect_ISP.js"></script>
   <script defer src="js/format_seconds.js"></script>
   <script defer src="js/format_downloaded.js"></script>
   <script defer src="js/audio_notification.js"></script>

--- a/js/detect_ISP.js
+++ b/js/detect_ISP.js
@@ -35,4 +35,4 @@ async function detectISP() {
         addLog('detectISP error: ' + e.message);
     }
 }
-detectISP();
+document.addEventListener('DOMContentLoaded', detectISP);


### PR DESCRIPTION
## Summary
- Trigger ISP detection after the DOM is ready instead of immediately
- Ensure ISP detection script loads synchronously without defer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893bce1990483298c06e3f2756c9ba2