### PR TITLE
Handle missing elements and log errors in detect_ISP

### DIFF
--- a/js/detect_ISP.js
+++ b/js/detect_ISP.js
@@ -30,9 +30,13 @@ async function detectISP() {
             operatorEl.classList.add('operator-lifecell');
         }
     } catch (e) {
-        document.getElementById('info').innerHTML =
-            '<div class="error-message">Не вдалося отримати інформацію про з’єднання</div>';
-        addLog('detectISP error: ' + e.message);
+        const infoEl = document.getElementById('info');
+        if (infoEl) {
+            infoEl.innerHTML = '<div class="error-message">Не вдалося отримати інформацію про з’єднання</div>';
+        }
+        if (typeof addLog === 'function') {
+            addLog('detectISP error: ' + e.message);
+        }
     }
 }
 document.addEventListener('DOMContentLoaded', detectISP);


### PR DESCRIPTION
## Summary
- Safely update connection info by ensuring the target element exists before modifying its contents
- Guard error logging in detect_ISP so logs are written only when addLog is available

## Testing
- `node - <<'NODE' ... NODE`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893bdc8b6bc8329b09e9188e3d02b0a