### PR TITLE
Throw error when IP info request fails

### DIFF
--- a/js/detect_ISP.js
+++ b/js/detect_ISP.js
@@ -2,6 +2,9 @@
 async function detectISP() {
     try {
         const res = await fetch('https://ipinfo.io/json?token=e2a0c701aef96b');
+        if (!res.ok) {
+            throw new Error(`IP info request failed: ${res.status}`);
+        }
         const data = await res.json();
 
         // Визначаємо operator


### PR DESCRIPTION
## Summary
- Handle non-200 responses from ipinfo fetch by throwing an error

## Testing
- `npm test` *(fails: package.json not found)*
- `node --check js/detect_ISP.js`


------
https://chatgpt.com/codex/tasks/task_e_6893bec849a88329ae8bb9b5254354bf