### PR TITLE
Fix nullish checks for numeric CSV fields

### DIFF
--- a/js/download_CSV.js
+++ b/js/download_CSV.js
@@ -68,14 +68,14 @@ function downloadCSV() {
                     `${operator};` +
                     `${record.speed.toFixed(2)};` +
                     `${(cumulative += record.downloadedDelta).toFixed(2)};` +
-                    `${record.elapsed || ""};` +
-                    `${record.latitude || ""};` +
-                    `${record.longitude || ""};` +
-                    `${record.altitude ? record.altitude.toFixed(0) : ""};` +
-                    `${record.gpsSpeed ? record.gpsSpeed.toFixed(1) : ""};` +
-                    `${record.distance ? record.distance.toFixed(1) : ""};` +
-                    `${record.accuracy ? record.accuracy.toFixed(1) : ""};` +
-                    `${record.heading ? record.heading.toFixed(1) : ""};`
+                    `${record.elapsed ?? ""};` +
+                    `${record.latitude ?? ""};` +
+                    `${record.longitude ?? ""};` +
+                    `${record.altitude !== null && record.altitude !== undefined ? record.altitude.toFixed(0) : ""};` +
+                    `${record.gpsSpeed !== null && record.gpsSpeed !== undefined ? record.gpsSpeed.toFixed(1) : ""};` +
+                    `${record.distance !== null && record.distance !== undefined ? record.distance.toFixed(1) : ""};` +
+                    `${record.accuracy !== null && record.accuracy !== undefined ? record.accuracy.toFixed(1) : ""};` +
+                    `${record.heading !== null && record.heading !== undefined ? record.heading.toFixed(1) : ""};`
                 );
             })
             .join("\n");


### PR DESCRIPTION
## Summary
- Ensure CSV export includes zero values by using nullish checks for numeric fields

## Testing
- `node --check js/download_CSV.js`
- `node` sample record to confirm zero outputs in CSV

------
https://chatgpt.com/codex/tasks/task_e_6893c06cc3088329998e8fbd36eeb2e8