### PR TITLE
Ensure CSV download always restores UI state

### DIFF
--- a/js/download_CSV.js
+++ b/js/download_CSV.js
@@ -10,88 +10,90 @@ function downloadCSV() {
     const downloadBtn = document.getElementById('downloadBtn');
     if (downloadBtn) downloadBtn.disabled = true;
 
-    let dateStr = '';
-    let timeStr = '';
+    try {
+        let dateStr = '';
+        let timeStr = '';
 
-    // ✨  Додали три нові заголовки після "Час" та колонку "Відстань" після "GPS Швидкість"
-    const headers =
-        "Часова мітка (мс);" +
-        "Дата;" +
-        "Час;" +
-        "Область;" +
-        "Район;" +
-        "Громада;" +
-        "Дорога;" +
-        "Оператор;" +
-        "Швидкість (Мбіт/с);" +
-        "Сумарно завантажено (МБ);" +
-        "Тривалість (с);" +
-        "Широта;" +
-        "Довгота;" +
-        "Висота (м);" +
-        "GPS Швидкість (км/год);" +
-        "Відстань (м);" +
-        "Точність (м);" +
-        "Напрямок (°)\n";
+        // ✨  Додали три нові заголовки після "Час" та колонку "Відстань" після "GPS Швидкість"
+        const headers =
+            "Часова мітка (мс);" +
+            "Дата;" +
+            "Час;" +
+            "Область;" +
+            "Район;" +
+            "Громада;" +
+            "Дорога;" +
+            "Оператор;" +
+            "Швидкість (Мбіт/с);" +
+            "Сумарно завантажено (МБ);" +
+            "Тривалість (с);" +
+            "Широта;" +
+            "Довгота;" +
+            "Висота (м);" +
+            "GPS Швидкість (км/год);" +
+            "Відстань (м);" +
+            "Точність (м);" +
+            "Напрямок (°)\n";
 
-    let cumulative = 0;
-    const csvContent =
-        headers +
-        speedData
-            .map((record) => {
-                // Перевірка, якщо зберігали Date – використовуємо напряму, інакше створюємо об’єкт Date
-                const ts =
-                    record.fullTimestamp instanceof Date
-                        ? record.fullTimestamp
-                        : new Date(record.fullTimestamp);
+        let cumulative = 0;
+        const csvContent =
+            headers +
+            speedData
+                .map((record) => {
+                    // Перевірка, якщо зберігали Date – використовуємо напряму, інакше створюємо об’єкт Date
+                    const ts =
+                        record.fullTimestamp instanceof Date
+                            ? record.fullTimestamp
+                            : new Date(record.fullTimestamp);
 
-                // Формати дати й часу з 2-цифровими компонентами
-                dateStr = ts.toLocaleDateString("uk-UA", {
-                    day: "2-digit",
-                    month: "2-digit",
-                    year: "numeric",
-                });
-                timeStr = ts.toLocaleTimeString("uk-UA", {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                    second: "2-digit",
-                });
+                    // Формати дати й часу з 2-цифровими компонентами
+                    dateStr = ts.toLocaleDateString("uk-UA", {
+                        day: "2-digit",
+                        month: "2-digit",
+                        year: "numeric",
+                    });
+                    timeStr = ts.toLocaleTimeString("uk-UA", {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                        second: "2-digit",
+                    });
 
-                return (
-                    `${ts.getTime()};` +                       // Часова мітка (мс)
-                    `${dateStr};` +                           // Дата
-                    `${timeStr};` +                           // Час (HH:MM:SS)
-                    `${record.region || ""};` +
-                    `${record.rayon || ""};` +
-                    `${record.hromada || ""};` +
-                    `${record.roadRef || ""};` +
-                    `${operator};` +
-                    `${record.speed.toFixed(2)};` +
-                    `${(cumulative += record.downloadedDelta).toFixed(2)};` +
-                    `${record.elapsed ?? ""};` +
-                    `${record.latitude ?? ""};` +
-                    `${record.longitude ?? ""};` +
-                    `${record.altitude !== null && record.altitude !== undefined ? record.altitude.toFixed(0) : ""};` +
-                    `${record.gpsSpeed !== null && record.gpsSpeed !== undefined ? record.gpsSpeed.toFixed(1) : ""};` +
-                    `${record.distance !== null && record.distance !== undefined ? record.distance.toFixed(1) : ""};` +
-                    `${record.accuracy !== null && record.accuracy !== undefined ? record.accuracy.toFixed(1) : ""};` +
-                    `${record.heading !== null && record.heading !== undefined ? record.heading.toFixed(1) : ""};`
-                );
-            })
-            .join("\n");
+                    return (
+                        `${ts.getTime()};` +                       // Часова мітка (мс)
+                        `${dateStr};` +                           // Дата
+                        `${timeStr};` +                           // Час (HH:MM:SS)
+                        `${record.region || ""};` +
+                        `${record.rayon || ""};` +
+                        `${record.hromada || ""};` +
+                        `${record.roadRef || ""};` +
+                        `${operator};` +
+                        `${record.speed.toFixed(2)};` +
+                        `${(cumulative += record.downloadedDelta).toFixed(2)};` +
+                        `${record.elapsed ?? ""};` +
+                        `${record.latitude ?? ""};` +
+                        `${record.longitude ?? ""};` +
+                        `${record.altitude !== null && record.altitude !== undefined ? record.altitude.toFixed(0) : ""};` +
+                        `${record.gpsSpeed !== null && record.gpsSpeed !== undefined ? record.gpsSpeed.toFixed(1) : ""};` +
+                        `${record.distance !== null && record.distance !== undefined ? record.distance.toFixed(1) : ""};` +
+                        `${record.accuracy !== null && record.accuracy !== undefined ? record.accuracy.toFixed(1) : ""};` +
+                        `${record.heading !== null && record.heading !== undefined ? record.heading.toFixed(1) : ""};`
+                    );
+                })
+                .join("\n");
 
-    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-    const link = document.createElement("a");
-    link.href = URL.createObjectURL(blob);
-    link.download = `${replaceSpacesWithUnderscore(operator)}_${dateStr}_${timeStr}.csv`;
-    link.style.display = "none";
-    document.body.appendChild(link);
-    link.click();
-    URL.revokeObjectURL(link.href);
-    document.body.removeChild(link);
+        const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+        const link = document.createElement("a");
+        link.href = URL.createObjectURL(blob);
+        link.download = `${replaceSpacesWithUnderscore(operator)}_${dateStr}_${timeStr}.csv`;
+        link.style.display = "none";
+        document.body.appendChild(link);
+        link.click();
+        URL.revokeObjectURL(link.href);
+        document.body.removeChild(link);
 
-    showNotification(t('dataDownloaded', 'Дані завантажено!'));
-
-    if (downloadBtn) downloadBtn.disabled = false;
-    isDownloading = false;
+        showNotification(t('dataDownloaded', 'Дані завантажено!'));
+    } finally {
+        if (downloadBtn) downloadBtn.disabled = false;
+        isDownloading = false;
+    }
 }


### PR DESCRIPTION
## Summary
- wrap CSV generation and download in a `try`/`finally` block
- guarantee the download button is re-enabled and downloading state reset on completion

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893c2134a908329b6dfa07893c01b2d