### PR TITLE
Validate marker popup generator before exporting HTML

### DIFF
--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -43,6 +43,10 @@ function downloadHTML() {
 
     const safeData = JSON.stringify(speedData).replace(/<\/script>/g, '<\\/script>');
 
+    if (typeof window.getMarkerPopupContent !== 'function') {
+        console.error('window.getMarkerPopupContent is not a function');
+        return;
+    }
     let getMarkerPopupContentSrc = window.getMarkerPopupContent.toString();
 
     if (!getMarkerPopupContentSrc.includes("distanceColumn")) {


### PR DESCRIPTION
## Summary
- ensure `window.getMarkerPopupContent` is a function before using `toString`
- log an error and abort HTML export when marker popup builder is missing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68942a721b7c8329a248bac542fed1bd