### PR TITLE
Encode HTML data with base64

### DIFF
--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -1,3 +1,16 @@
+function encodeDataForScript(data) {
+    const json = JSON.stringify(data);
+    if (typeof Buffer !== 'undefined') {
+        return Buffer.from(json, 'utf-8').toString('base64');
+    }
+    const uint8 = new TextEncoder().encode(json);
+    let binary = '';
+    for (const b of uint8) {
+        binary += String.fromCharCode(b);
+    }
+    return btoa(binary);
+}
+
 function downloadHTML() {
     if (typeof speedData === 'undefined' || !Array.isArray(speedData)) {
         console.error('speedData is undefined');
@@ -41,7 +54,7 @@ function downloadHTML() {
 
     const baseFileName = `${replaceSpacesWithUnderscore(operator)}_${dateStr}_${timeStr}`;
 
-    const safeData = JSON.stringify(speedData).replace(/<\/script>/g, '<\\/script>');
+    const encodedData = encodeDataForScript(speedData);
 
     if (typeof window.getMarkerPopupContent !== 'function') {
         console.error('window.getMarkerPopupContent is not a function');
@@ -165,7 +178,8 @@ function getColorBySpeed(speed) {
 }
 
 /* ------------------ 3. Дані ------------------ */
-const data = ${safeData};
+  const dataEncoded = "${encodedData}";
+  const data = JSON.parse(new TextDecoder().decode(Uint8Array.from(atob(dataEncoded), c => c.charCodeAt(0))));
 /* ------------------ 4. Ініціалізація карти ------------------ */
 const map = L.map('map');
 const osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -266,4 +280,8 @@ L.control.layers(null, overlays, { collapsed: true }).addTo(map);
     document.body.removeChild(link);
 
     showNotification(t('htmlDownloaded', 'HTML файл завантажено!'));
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { encodeDataForScript };
 }

--- a/tests/script_escape.test.js
+++ b/tests/script_escape.test.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+const { TextDecoder } = require('util');
+const { encodeDataForScript } = require('../js/download_HTML.js');
+
+const payload = [{ message: '</script><script>alert(1)</script>' }];
+const encoded = encodeDataForScript(payload);
+
+// Encoded data should not contain closing script tags or angle brackets
+assert(!/<\/script>/i.test(encoded), 'Encoded string should not contain </script>');
+assert(!/[<>]/.test(encoded), 'Encoded string should not contain < or > characters');
+
+// Decoding should recover original data
+const decodedJson = new TextDecoder().decode(Buffer.from(encoded, 'base64'));
+const decoded = JSON.parse(decodedJson);
+assert.deepStrictEqual(decoded, payload, 'Decoded data should match original');
+
+console.log('script escape test passed');


### PR DESCRIPTION
## Summary
- encode speed data as base64 before embedding into downloaded HTML
- add test ensuring base64 encoding prevents script block escapes

## Testing
- `node tests/script_escape.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68942d6304088329bfd7a264eca28741