### PR TITLE
Sanitize filenames for KML downloads

### DIFF
--- a/js/download_KML.js
+++ b/js/download_KML.js
@@ -14,16 +14,20 @@ function downloadKML() {
             lastRecord.fullTimestamp instanceof Date
                 ? lastRecord.fullTimestamp
                 : new Date(lastRecord.fullTimestamp);
-        dateStr = ts.toLocaleDateString('uk-UA', {
-            day: '2-digit',
-            month: '2-digit',
-            year: 'numeric',
-        });
-        timeStr = ts.toLocaleTimeString('uk-UA', {
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit',
-        });
+        dateStr = ts
+            .toLocaleDateString('uk-UA', {
+                day: '2-digit',
+                month: '2-digit',
+                year: 'numeric',
+            })
+            .replace(/[^\d]+/g, '-');
+        timeStr = ts
+            .toLocaleTimeString('uk-UA', {
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit',
+            })
+            .replace(/[^\d]+/g, '-');
     }
 
     const baseFileName = `${replaceSpacesWithUnderscore(operator)}_${dateStr}_${timeStr}`;

--- a/js/replace_spaces_with_underscore.js
+++ b/js/replace_spaces_with_underscore.js
@@ -1,3 +1,5 @@
 function replaceSpacesWithUnderscore(str) {
-  return str.replace(/ /g, '_');
+    return str
+        .replace(/\s+/g, '_')
+        .replace(/[^\w-]/g, '');
 }


### PR DESCRIPTION
## Summary
- Sanitize date and time strings used in KML filenames to remove unsafe characters
- Harden replaceSpacesWithUnderscore to drop illegal filename characters

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/download_KML.js js/replace_spaces_with_underscore.js`

------
https://chatgpt.com/codex/tasks/task_e_689434e9b5908329b8c1d30a2f186e59