### PR TITLE
Handle non-numeric downloadedDelta

### DIFF
--- a/js/download_KML.js
+++ b/js/download_KML.js
@@ -45,7 +45,14 @@ function downloadKML() {
     speedData.forEach((record, idx) => {
         if (record.latitude == null || record.longitude == null) return;
 
-        cumulative += record.downloadedDelta;
+        if (Number.isNaN(Number(record.downloadedDelta))) {
+            console.warn(
+                'Skipping record with non-numeric downloadedDelta',
+                record
+            );
+            return;
+        }
+        cumulative += Number(record.downloadedDelta) || 0;
 
         const altitude = record.altitude ? record.altitude.toFixed(1) : '0';
 


### PR DESCRIPTION
## Summary
- Guard KML export against non-numeric `downloadedDelta`
- Skip invalid records and log a warning

## Testing
- `node --check js/download_KML.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894360198788329877075da07a6de5d