### PR TITLE
chore: release object URL

### DIFF
--- a/js/download_KML.js
+++ b/js/download_KML.js
@@ -126,6 +126,7 @@ function downloadKML() {
     link.download = `${baseFileName}.kml`;
     document.body.appendChild(link);
     link.click();
+    URL.revokeObjectURL(link.href);
     document.body.removeChild(link);
 
     showNotification(t('kmlDownloaded', 'KML файл завантажено!'));


### PR DESCRIPTION
## Summary
- revoke temporary object URL after downloading KML files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689437d43ce88329a5f4750e5c26a63d