### PR TITLE
Handle chart download link cleanup

### DIFF
--- a/js/download_chart.js
+++ b/js/download_chart.js
@@ -6,7 +6,9 @@ function downloadChart() {
         .toISOString()
         .slice(0, 10)}.png`;
     link.href = speedChart.toBase64Image();
+    document.body.appendChild(link);
     link.click();
+    document.body.removeChild(link);
 
     showNotification(t('chartExported', 'Графік експортовано!'));
 }


### PR DESCRIPTION
## Summary
- Append download link to document before triggering click
- Remove temporary link after initiating download

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894397d5fb08329abc347118c634217