### PR TITLE
Handle errors when downloading chart

### DIFF
--- a/js/download_chart.js
+++ b/js/download_chart.js
@@ -1,14 +1,20 @@
 function downloadChart() {
     if (!speedChart) return;
 
-    const link = document.createElement("a");
-    link.download = `speed_chart_${new Date()
-        .toISOString()
-        .slice(0, 10)}.png`;
-    link.href = speedChart.toBase64Image();
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+    try {
+        const link = document.createElement("a");
+        link.download = `speed_chart_${new Date()
+            .toISOString()
+            .slice(0, 10)}.png`;
+        link.href = speedChart.toBase64Image();
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
 
-    showNotification(t('chartExported', 'Графік експортовано!'));
+        showNotification(t('chartExported', 'Графік експортовано!'));
+    } catch (e) {
+        showNotification(
+            t('chartExportError', 'Не вдалося експортувати графік')
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- wrap chart download logic in try/catch
- show notification if chart export fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68943a1eb5c88329aa236f0a822d4712