### PR TITLE
refactor: use lat-lon order in road functions

### DIFF
--- a/js/data_point.js
+++ b/js/data_point.js
@@ -46,8 +46,8 @@ async function saveDataPoint() {
             currentGPSData.latitude
         )) || {};
     const roadInfo = find_road(
-        currentGPSData.longitude,
-        currentGPSData.latitude
+        currentGPSData.latitude,
+        currentGPSData.longitude
     );
 
     const now = new Date();

--- a/js/find_admin_unit.js
+++ b/js/find_admin_unit.js
@@ -159,7 +159,7 @@ function distanceToSegment(lat, lon, lat1, lon1, lat2, lon2) {
     return Math.sqrt(dx * dx + dy * dy);
 }
 
-function isPointNearLineString(lon, lat, coords, threshold) {
+function isPointNearLineString(lat, lon, coords, threshold) {
     for (let i = 0; i < coords.length - 1; i++) {
         const [lon1, lat1] = coords[i];
         const [lon2, lat2] = coords[i + 1];
@@ -170,26 +170,26 @@ function isPointNearLineString(lon, lat, coords, threshold) {
     return false;
 }
 
-function isPointNearRoad(lon, lat, feature, threshold) {
+function isPointNearRoad(lat, lon, feature, threshold) {
     const geom = feature.geometry;
     if (!geom) return false;
     if (geom.type === 'LineString') {
-        return isPointNearLineString(lon, lat, geom.coordinates, threshold);
+        return isPointNearLineString(lat, lon, geom.coordinates, threshold);
     } else if (geom.type === 'MultiLineString') {
         for (const line of geom.coordinates) {
-            if (isPointNearLineString(lon, lat, line, threshold)) return true;
+            if (isPointNearLineString(lat, lon, line, threshold)) return true;
         }
     }
     return false;
 }
 
-function find_road(lon, lat, threshold = 50) {
+function find_road(lat, lon, threshold = 50) {
     const types = ['international', 'national', 'regional', 'territorial'];
     for (const type of types) {
         const data = roadData[type];
         if (!data) continue;
         for (const feature of data.features) {
-            if (isPointNearRoad(lon, lat, feature, threshold)) {
+            if (isPointNearRoad(lat, lon, feature, threshold)) {
                 return feature.properties;
             }
         }

--- a/js/update_GPS_info.js
+++ b/js/update_GPS_info.js
@@ -168,7 +168,7 @@ async function updateRoadInfo() {
         return;
     }
 
-    const road = find_road(currentGPSData.longitude, currentGPSData.latitude);
+    const road = find_road(currentGPSData.latitude, currentGPSData.longitude);
     announceRoadChange(road);
 
     if (road) {


### PR DESCRIPTION
## Summary
- refactor road proximity helpers to accept `(lat, lon)` matching distance calculation
- update road lookups to pass latitude before longitude

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68943e032c90832988dc1c73b1f00c2f