### PR TITLE
Use translation for data size units

### DIFF
--- a/js/format_downloaded.js
+++ b/js/format_downloaded.js
@@ -1,12 +1,14 @@
 function formatDownloaded(bytes) {
     const MB = 1024 * 1024;
     const GB = MB * 1024;
+    const gbLabel = t('gbShort', 'GB');
+    const mbLabel = t('mbShort', 'MB');
     if (bytes >= GB) {
         const gb = Math.floor(bytes / GB);
         const mb = Math.floor((bytes % GB) / MB);
-        return `${gb} GB ${mb} MB`;
+        return `${gb} ${gbLabel} ${mb} ${mbLabel}`;
     } else {
         const mb = Math.floor(bytes / MB);
-        return `${mb} MB`;
+        return `${mb} ${mbLabel}`;
     }
 }

--- a/translations/en.js
+++ b/translations/en.js
@@ -130,5 +130,7 @@ window.i18n.en = {
   hoursShort: "h",
   minutesShort: "m",
   secondsShort: "s",
+  gbShort: "GB",
+  mbShort: "MB",
   directionLabels: ["N", "NE", "E", "SE", "S", "SW", "W", "NW"]
 };

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -130,5 +130,7 @@ window.i18n.uk = {
   hoursShort: "г",
   minutesShort: "хв",
   secondsShort: "с",
+  gbShort: "ГБ",
+  mbShort: "МБ",
   directionLabels: ["Пн", "ПнСх", "Сх", "ПдСх", "Пд", "ПдЗх", "Зх", "ПнЗх"]
 };


### PR DESCRIPTION
## Summary
- use translation keys for GB/MB in format_downloaded
- add `gbShort` and `mbShort` to English and Ukrainian translations

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68944159a2788329a07ebac0b23a87aa