### PR TITLE
Avoid displaying 0 MB in download size formatting

### DIFF
--- a/js/format_downloaded.js
+++ b/js/format_downloaded.js
@@ -6,7 +6,10 @@ function formatDownloaded(bytes) {
     if (bytes >= GB) {
         const gb = Math.floor(bytes / GB);
         const mb = Math.floor((bytes % GB) / MB);
-        return `${gb} ${gbLabel} ${mb} ${mbLabel}`;
+        if (mb > 0) {
+            return `${gb} ${gbLabel} ${mb} ${mbLabel}`;
+        }
+        return `${gb} ${gbLabel}`;
     } else {
         const mb = Math.floor(bytes / MB);
         return `${mb} ${mbLabel}`;


### PR DESCRIPTION
## Summary
- Skip displaying megabyte part when size is an exact number of gigabytes
- Preserve combined gigabyte and megabyte display when megabytes are present

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894424883b08329ae600b398b9bbf29