### PR TITLE
feat: add KB and B formatting for download size

### DIFF
--- a/js/format_downloaded.js
+++ b/js/format_downloaded.js
@@ -1,17 +1,43 @@
 function formatDownloaded(bytes) {
-    const MB = 1024 * 1024;
+    const KB = 1024;
+    const MB = KB * 1024;
     const GB = MB * 1024;
     const gbLabel = t('gbShort', 'GB');
     const mbLabel = t('mbShort', 'MB');
+    const kbLabel = t('kbShort', 'KB');
+    const bLabel = t('bShort', 'B');
     if (bytes >= GB) {
         const gb = Math.floor(bytes / GB);
-        const mb = Math.floor((bytes % GB) / MB);
+        const remainder = bytes % GB;
+        const mb = Math.floor(remainder / MB);
+        const kb = Math.floor((remainder % MB) / KB);
+        const b = remainder % KB;
         if (mb > 0) {
             return `${gb} ${gbLabel} ${mb} ${mbLabel}`;
+        } else if (kb > 0) {
+            return `${gb} ${gbLabel} ${kb} ${kbLabel}`;
+        } else if (b > 0) {
+            return `${gb} ${gbLabel} ${b} ${bLabel}`;
         }
         return `${gb} ${gbLabel}`;
-    } else {
+    } else if (bytes >= MB) {
         const mb = Math.floor(bytes / MB);
+        const remainder = bytes % MB;
+        const kb = Math.floor(remainder / KB);
+        const b = remainder % KB;
+        if (kb > 0) {
+            return `${mb} ${mbLabel} ${kb} ${kbLabel}`;
+        } else if (b > 0) {
+            return `${mb} ${mbLabel} ${b} ${bLabel}`;
+        }
         return `${mb} ${mbLabel}`;
+    } else if (bytes >= KB) {
+        const kb = Math.floor(bytes / KB);
+        const b = bytes % KB;
+        if (b > 0) {
+            return `${kb} ${kbLabel} ${b} ${bLabel}`;
+        }
+        return `${kb} ${kbLabel}`;
     }
+    return `${bytes} ${bLabel}`;
 }

--- a/translations/en.js
+++ b/translations/en.js
@@ -132,5 +132,7 @@ window.i18n.en = {
   secondsShort: "s",
   gbShort: "GB",
   mbShort: "MB",
+  kbShort: "KB",
+  bShort: "B",
   directionLabels: ["N", "NE", "E", "SE", "S", "SW", "W", "NW"]
 };

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -132,5 +132,7 @@ window.i18n.uk = {
   secondsShort: "с",
   gbShort: "ГБ",
   mbShort: "МБ",
+  kbShort: "КБ",
+  bShort: "Б",
   directionLabels: ["Пн", "ПнСх", "Сх", "ПдСх", "Пд", "ПдЗх", "Зх", "ПнЗх"]
 };


### PR DESCRIPTION
## Summary
- extend download formatting to support kilobytes and bytes
- add English and Ukrainian translations for KB and B labels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894431d811883299b0f4a1f920de422