### PR TITLE
Validate input for formatDownloaded

### DIFF
--- a/js/format_downloaded.js
+++ b/js/format_downloaded.js
@@ -1,4 +1,11 @@
+/**
+ * Formats a byte count into a human readable string.
+ * Returns '0' if the input is not a non-negative number.
+ */
 function formatDownloaded(bytes) {
+    if (typeof bytes !== 'number' || Number.isNaN(bytes) || bytes < 0) {
+        return '0';
+    }
     const KB = 1024;
     const MB = KB * 1024;
     const GB = MB * 1024;


### PR DESCRIPTION
## Summary
- ensure `formatDownloaded` returns `0` when given a non-number or negative value
- document the validation behavior

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894441a448c8329911d47d9c604e7e5