### PR TITLE
Announce first hromada change

### DIFF
--- a/js/hromada_change_announcer.js
+++ b/js/hromada_change_announcer.js
@@ -7,8 +7,9 @@ function announceAdminChange(info) {
         return;
     }
 
-    if (settings.voiceHromadaChange && lastAdminUnit.hromada) {
+    if (settings.voiceHromadaChange) {
         if (
+            !lastAdminUnit.hromada ||
             lastAdminUnit.hromada !== info.hromada ||
             lastAdminUnit.rayon !== info.rayon ||
             lastAdminUnit.region !== info.region


### PR DESCRIPTION
## Summary
- announce hromada change even when no previous data is stored
- trigger voice announcement when any admin unit field differs or is missing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894488442a88329ae6a920937654a33