### PR TITLE
Handle missing admin info in announcer

### DIFF
--- a/js/hromada_change_announcer.js
+++ b/js/hromada_change_announcer.js
@@ -7,6 +7,10 @@ function announceAdminChange(info) {
         return;
     }
 
+    if (!info.region || !info.rayon || !info.hromada) {
+        console.warn('announceAdminChange: incomplete info', info);
+    }
+
     if (settings.voiceHromadaChange) {
         if (
             !lastAdminUnit.hromada ||
@@ -14,7 +18,11 @@ function announceAdminChange(info) {
             lastAdminUnit.rayon !== info.rayon ||
             lastAdminUnit.region !== info.region
         ) {
-            speak(`Вас вітає ${info.hromada} ${info.rayon} ${info.region}`);
+            const region = info.region ?? '';
+            const rayon = info.rayon ?? '';
+            const hromada = info.hromada ?? '';
+            const message = `Вас вітає ${hromada} ${rayon} ${region}`;
+            speak(message.trim());
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure admin change announcer gracefully handles missing fields and trims message
- warn when key fields are absent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894494c85c483299ba0d172a20e04ed