### PR TITLE
Guard speedChart dataset before setting label

### DIFF
--- a/js/lang.js
+++ b/js/lang.js
@@ -41,7 +41,7 @@ function setLanguage(lang) {
     applyTranslations();
     const select = document.getElementById('languageSelect');
     if (select) select.value = lang;
-    if (speedChart && window.i18n && window.i18n[currentLang]) {
+    if (speedChart?.data?.datasets?.[0] && window.i18n?.[currentLang]) {
         speedChart.data.datasets[0].label =
             window.i18n[currentLang].speedChartLabel ||
             speedChart.data.datasets[0].label;


### PR DESCRIPTION
## Summary
- Guard `setLanguage` against missing `speedChart` data before updating the chart label

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68944d70fd9c832991ebe6d1153da76a