### PR TITLE
refactor: use globals for language utilities

### DIFF
--- a/js/lang.js
+++ b/js/lang.js
@@ -1,8 +1,4 @@
-import { currentLang as initialLang, speedChart } from './config.js';
-import { updateGPSInfo } from './update_GPS_info.js';
-import { updateDatabaseInfo } from './update_database_info.js';
-
-let currentLang = initialLang || localStorage.getItem('lang') || 'uk';
+let currentLang = window.currentLang || localStorage.getItem('lang') || 'uk';
 
 function t(key, fallback = '') {
     const dict = window.i18n && window.i18n[currentLang];


### PR DESCRIPTION
## Summary
- stop importing config and helper modules in lang.js
- initialize `currentLang` from `window.currentLang` or localStorage
- rely on global `updateGPSInfo` and `updateDatabaseInfo`

## Testing
- `node --check js/lang.js && echo "syntax OK"`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894526c277483298ca189931d61250f