### PR TITLE
Expose initLanguage globally

### DIFF
--- a/js/lang.js
+++ b/js/lang.js
@@ -56,3 +56,5 @@ function initLanguage() {
         setLanguage(currentLang);
     }
 }
+
+window.initLanguage = initLanguage;


### PR DESCRIPTION
## Summary
- expose `initLanguage` on the `window` object so other scripts can call it

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894541a934883298f402115d55f8a46