### PR TITLE
Localize test summary log

### DIFF
--- a/js/log_test_summary.js
+++ b/js/log_test_summary.js
@@ -9,10 +9,16 @@ function logTestSummary() {
         ? (speedStats.sum / speedStats.count).toFixed(2)
         : "0.00";
     const min = speedStats.min === Infinity ? 0 : speedStats.min;
+    const secLabel = t('secondsShort', 'с');
+    const speedUnit = t('mbpsShort', 'Мбіт/с');
     addLog(
-        `Результати тесту: час ${elapsed} с, дані ${downloadedFormatted}, ` +
-            `середня швидкість ${avg} Мбіт/с, ` +
-            `макс ${speedStats.max.toFixed(2)} Мбіт/с, ` +
-            `мін ${min === 0 ? "0.00" : min.toFixed(2)} Мбіт/с`
+        `${t('testResults', 'Результати тесту')}: ` +
+            `${t('testResultsTime', 'час')} ${elapsed} ${secLabel}, ` +
+            `${t('testResultsData', 'дані')} ${downloadedFormatted}, ` +
+            `${t('testResultsAvgSpeed', 'середня швидкість')} ${avg} ${speedUnit}, ` +
+            `${t('testResultsMax', 'макс')} ${speedStats.max.toFixed(2)} ${speedUnit}, ` +
+            `${t('testResultsMin', 'мін')} ${
+                min === 0 ? '0.00' : min.toFixed(2)
+            } ${speedUnit}`
     );
 }

--- a/translations/en.js
+++ b/translations/en.js
@@ -116,6 +116,12 @@ window.i18n.en = {
   fullscreenDisabled: "Fullscreen disabled",
   themeSwitchedDark: "Switched to dark theme",
   themeSwitchedLight: "Switched to light theme",
+  testResults: "Test results",
+  testResultsTime: "time",
+  testResultsData: "data",
+  testResultsAvgSpeed: "average speed",
+  testResultsMax: "max",
+  testResultsMin: "min",
   storage50: "Local storage 50% full!",
   storage90: "Local storage 90% full!",
   storage95: "Local storage 95% full!",
@@ -134,5 +140,6 @@ window.i18n.en = {
   mbShort: "MB",
   kbShort: "KB",
   bShort: "B",
+  mbpsShort: "Mbps",
   directionLabels: ["N", "NE", "E", "SE", "S", "SW", "W", "NW"]
 };

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -116,6 +116,12 @@ window.i18n.uk = {
   fullscreenDisabled: "Повноекранний режим вимкнено",
   themeSwitchedDark: "Переключено на темну тему",
   themeSwitchedLight: "Переключено на світлу тему",
+  testResults: "Результати тесту",
+  testResultsTime: "час",
+  testResultsData: "дані",
+  testResultsAvgSpeed: "середня швидкість",
+  testResultsMax: "макс",
+  testResultsMin: "мін",
   storage50: "Локальне сховище заповнене на 50%!",
   storage90: "Локальне сховище заповнене на 90%!",
   storage95: "Локальне сховище заповнене на 95%!",
@@ -134,5 +140,6 @@ window.i18n.uk = {
   mbShort: "МБ",
   kbShort: "КБ",
   bShort: "Б",
+  mbpsShort: "Мбіт/с",
   directionLabels: ["Пн", "ПнСх", "Сх", "ПдСх", "Пд", "ПдЗх", "Зх", "ПнЗх"]
 };


### PR DESCRIPTION
## Summary
- localize test result log strings using translation keys
- add English and Ukrainian translations for new test summary phrases and speed unit

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68945641a20483299a5d0e327635799d