### PR TITLE
refactor: extract logging helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
   <script defer src="js/config.js"></script>
   <script defer src="js/lang.js"></script>
   <script defer src="js/storage.js"></script>
+  <script src="js/log.js"></script>
   <script src="js/detect_ISP.js"></script>
   <script defer src="js/format_seconds.js"></script>
   <script defer src="js/format_downloaded.js"></script>

--- a/js/log.js
+++ b/js/log.js
@@ -1,0 +1,3 @@
+function addLog(msg) {
+    console.log(`[${new Date().toLocaleTimeString()}] ${msg}`);
+}

--- a/js/log_test_summary.js
+++ b/js/log_test_summary.js
@@ -1,7 +1,3 @@
-function addLog(msg) {
-    console.log(`[${new Date().toLocaleTimeString()}] ${msg}`);
-}
-
 function logTestSummary() {
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
     const downloadedFormatted = formatDownloaded(totalBytes);


### PR DESCRIPTION
## Summary
- centralize `addLog` into new `js/log.js`
- include `log.js` before scripts using logging
- trim `log_test_summary.js` to rely on shared logger

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894585dee8c8329b39c6537033f2f4d