### PR TITLE
Use global currentLang variable

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -33,7 +33,7 @@ const DEFAULT_DIRECTION_LABELS = {
     en: ["N", "NE", "E", "SE", "S", "SW", "W", "NW"],
 };
 
-let currentLang = localStorage.getItem('lang') || 'uk';
+window.currentLang = window.currentLang || localStorage.getItem('lang') || 'uk';
 
 // Глобальні змінні
 let testActive = false;

--- a/js/lang.js
+++ b/js/lang.js
@@ -1,12 +1,10 @@
-let currentLang = window.currentLang || localStorage.getItem('lang') || 'uk';
-
 function t(key, fallback = '') {
-    const dict = window.i18n && window.i18n[currentLang];
+    const dict = window.i18n && window.i18n[window.currentLang];
     return (dict && key in dict) ? dict[key] : fallback;
 }
 
 function applyTranslations() {
-    const dict = window.i18n && window.i18n[currentLang];
+    const dict = window.i18n && window.i18n[window.currentLang];
     if (!dict) return;
     document.querySelectorAll('[data-i18n]').forEach(el => {
         const key = el.getAttribute('data-i18n');
@@ -20,7 +18,7 @@ function applyTranslations() {
             el.setAttribute('aria-label', dict[key]);
         }
     });
-    document.documentElement.lang = currentLang;
+    document.documentElement.lang = window.currentLang;
     if ('appTitle' in dict) {
         document.title = dict.appTitle;
     }
@@ -31,15 +29,14 @@ function applyTranslations() {
 }
 
 function setLanguage(lang) {
-    currentLang = lang;
     window.currentLang = lang;
     localStorage.setItem('lang', lang);
     applyTranslations();
     const select = document.getElementById('languageSelect');
     if (select) select.value = lang;
-    if (speedChart?.data?.datasets?.[0] && window.i18n?.[currentLang]) {
+    if (speedChart?.data?.datasets?.[0] && window.i18n?.[window.currentLang]) {
         speedChart.data.datasets[0].label =
-            window.i18n[currentLang].speedChartLabel ||
+            window.i18n[window.currentLang].speedChartLabel ||
             speedChart.data.datasets[0].label;
         speedChart.update();
     }
@@ -52,8 +49,8 @@ function setLanguage(lang) {
 }
 
 function initLanguage() {
-    if (typeof currentLang !== 'undefined') {
-        setLanguage(currentLang);
+    if (typeof window.currentLang !== 'undefined') {
+        setLanguage(window.currentLang);
     }
 }
 


### PR DESCRIPTION
## Summary
- initialize `currentLang` on the global `window` object to share state
- update language helpers to read `window.currentLang`

## Testing
- `node --check js/config.js && node --check js/lang.js`
- `npm test` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68945c9bf6fc832994dc7ba4ebdddec4