### PR TITLE
Ensure global currentLang variable and DOM init

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -34,6 +34,7 @@ const DEFAULT_DIRECTION_LABELS = {
 };
 
 window.currentLang = window.currentLang || localStorage.getItem('lang') || 'uk';
+let currentLang = window.currentLang;
 
 // Глобальні змінні
 let testActive = false;

--- a/js/lang.js
+++ b/js/lang.js
@@ -30,6 +30,7 @@ function applyTranslations() {
 
 function setLanguage(lang) {
     window.currentLang = lang;
+    currentLang = lang;
     localStorage.setItem('lang', lang);
     applyTranslations();
     const select = document.getElementById('languageSelect');


### PR DESCRIPTION
## Summary
- Sync `currentLang` global with `window.currentLang`
- Keep language state updated in `setLanguage` to avoid reference errors

## Testing
- `node test_lang.js` (custom script verifying `initLanguage` export and DOMContentLoaded invocation)

------
https://chatgpt.com/codex/tasks/task_e_68945e2665d08329878d8bc5606000a5