### PR TITLE
Handle missing speed in map popups

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -97,12 +97,16 @@ function getMarkerPopupContent(point) {
         return label.endsWith(':') ? label : label + ':';
     }
 
+    const speedValue = Number.isFinite(point.speed)
+        ? point.speed.toFixed(2)
+        : na;
+
     const rows = [
         [ensureColon(t('timestampMsLabel', 'Часова мітка (мс)')), ts.getTime()],
         [ensureColon(t('dateLabel', 'Дата')), dateStr],
         [ensureColon(t('timeLabel', 'Час')), timeStr],
         [ensureColon(t('operatorLabel', 'Оператор')), operator || na],
-        [ensureColon(t('speedColumn', 'Швидкість завантаження Мбіт/с')), point.speed.toFixed(2)],
+        [ensureColon(t('speedColumn', 'Швидкість завантаження Мбіт/с')), speedValue],
         [ensureColon(t('latColumn', 'Широта')),
             point.latitude != null ? point.latitude.toFixed(6) : na],
         [ensureColon(t('lonColumn', 'Довгота')),


### PR DESCRIPTION
## Summary
- Ensure map marker popup handles missing speed values by checking if `point.speed` is numeric and falling back to `N/A`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689461b6d5888329bbefca87b939f574