### PR TITLE
Safely handle missing speed data before adding map markers

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -47,7 +47,7 @@ function initMap() {
     updateRoadLayers();
 
     // Add previously stored markers without centering on each
-    if (speedData.length > 0) {
+    if (typeof speedData !== 'undefined' && Array.isArray(speedData) && speedData.length > 0) {
         speedData.forEach((pt) => addMapMarker(pt, false));
         const last = speedData[speedData.length - 1];
         if (last.latitude != null && last.longitude != null) {


### PR DESCRIPTION
## Summary
- Guard `initMap` against undefined or non-array `speedData`
- Only add map markers when valid speed data exists

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894658f7ae483298956ca72040f1ee4