### PR TITLE
Add map.setZoom presence check in zoomTo18

### DIFF
--- a/js/map_zoom.js
+++ b/js/map_zoom.js
@@ -2,7 +2,9 @@ function zoomTo18() {
     if (typeof initMapIfNeeded === 'function') {
         initMapIfNeeded();
     }
-    if (map) {
+    if (map && typeof map.setZoom === 'function') {
         map.setZoom(18);
+    } else {
+        console.warn('Map instance або метод setZoom відсутні');
     }
 }


### PR DESCRIPTION
## Summary
- add guard to verify map and setZoom function before zooming
- log a warning when map or setZoom is missing

## Testing
- `npm test` (fails: Could not read package.json)
- `node <<'NODE'
const fs=require('fs');
const vm=require('vm');
const code=fs.readFileSync('./js/map_zoom.js','utf8');
vm.runInThisContext(code);
global.map={};
zoomTo18();
NODE`


------
https://chatgpt.com/codex/tasks/task_e_6894683358fc8329b8daf26f9e28f0b9