### PR TITLE
Handle null coordinates in point distance calculations

### DIFF
--- a/js/point_distance.js
+++ b/js/point_distance.js
@@ -1,5 +1,8 @@
 function getDistanceToLastPoint(lat, lon) {
-    if (!lastSavedGPSData.latitude || !lastSavedGPSData.longitude) {
+    if (lastSavedGPSData.latitude == null || lastSavedGPSData.longitude == null) {
+        return 0;
+    }
+    if (lat == null || lon == null) {
         return 0;
     }
     const distance = calculateDistance(


### PR DESCRIPTION
## Summary
- Avoid false negatives when previous GPS data has zero values by checking for `null` explicitly
- Guard against `null` latitude/longitude inputs before calculating distance

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68946af6bbf483298a6a60e5934720bd