### PR TITLE
feat: validate coordinates in distance calculation

### DIFF
--- a/js/point_distance.js
+++ b/js/point_distance.js
@@ -1,8 +1,14 @@
 function getDistanceToLastPoint(lat, lon) {
     if (lastSavedGPSData.latitude == null || lastSavedGPSData.longitude == null) {
+        if (typeof addLog === "function") {
+            addLog("getDistanceToLastPoint: missing last GPS data");
+        }
         return 0;
     }
     if (lat == null || lon == null) {
+        if (typeof addLog === "function") {
+            addLog(`getDistanceToLastPoint: invalid coordinates lat=${lat}, lon=${lon}`);
+        }
         return 0;
     }
     const distance = calculateDistance(


### PR DESCRIPTION
## Summary
- log and return 0 when lat/lon or last GPS data is null before computing distance

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68946ba466a08329ae8fd27893f41c38