### PR TITLE
feat: add max point distance constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Use the **Завантажити CSV**, **Завантажити KML**, or **З�
 
 Visit [https://www.gonettest.com](https://www.gonettest.com) for the hosted version.
 
+## Configuration
+
+Application behaviour can be adjusted by editing constants in [`js/config.js`](js/config.js).
+The `MAX_POINT_DISTANCE` constant defines the maximum distance in meters allowed
+between successive GPS points. Distances larger than this value are ignored to
+filter out GPS glitches. The default value is `100`.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/js/config.js
+++ b/js/config.js
@@ -10,6 +10,8 @@ const SPEECH_RATE = 0.8;
 const GPS_TIMEOUT = 5000;
 const GPS_MAX_AGE = 1000;
 const MAX_GPS_ACCURACY = 10;
+// Maximum distance (m) between consecutive GPS points to consider them valid
+const MAX_POINT_DISTANCE = 100;
 const DEFAULT_FETCH_TIMEOUT = 1000;
 const STREAM_READ_TIMEOUT = 500000;
 const UI_UPDATE_INTERVAL = 1000;

--- a/js/point_distance.js
+++ b/js/point_distance.js
@@ -17,7 +17,8 @@ function getDistanceToLastPoint(lat, lon) {
         lat,
         lon
     );
-    return distance <= 100 ? distance : 0;
+    // Ignore points farther than MAX_POINT_DISTANCE meters to avoid GPS glitches
+    return distance <= MAX_POINT_DISTANCE ? distance : 0;
 }
 
 window.getDistanceToLastPoint = getDistanceToLastPoint;


### PR DESCRIPTION
## Summary
- add `MAX_POINT_DISTANCE` setting to centralize GPS point distance limit
- use the new constant in point distance calculation
- document configuration option in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68946c4b598883299d3ccf5dc8caa0ce