### PR TITLE
Use absolute path for service worker

### DIFF
--- a/js/registration_service_worker.js
+++ b/js/registration_service_worker.js
@@ -9,7 +9,7 @@
 if ("serviceWorker" in navigator) {
     window.addEventListener("load", () => {
         navigator.serviceWorker
-            .register("./sw.js", { scope: "./" })
+            .register("/sw.js", { scope: "/" })
             .then((registration) => console.log(registration.scope))
             .catch((err) => {
                 console.error("Service worker registration failed:", err);


### PR DESCRIPTION
## Summary
- register service worker using root-relative path for consistent scope across app pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68947471f20c8329b060e9eeeb2f9ab1