### PR TITLE
Show service worker registration errors

### DIFF
--- a/js/registration_service_worker.js
+++ b/js/registration_service_worker.js
@@ -14,7 +14,12 @@ if ("serviceWorker" in navigator) {
             .catch((err) => {
                 console.error("Service worker registration failed:", err);
                 if (typeof showNotification === "function") {
-                    showNotification("Service worker error");
+                    const baseMessage = t(
+                        "serviceWorkerError",
+                        "Помилка Service Worker"
+                    );
+                    const details = err?.message || err;
+                    showNotification(`${baseMessage}: ${details}`);
                 }
             });
     });

--- a/translations/en.js
+++ b/translations/en.js
@@ -116,6 +116,7 @@ window.i18n.en = {
   fullscreenDisabled: "Fullscreen disabled",
   themeSwitchedDark: "Switched to dark theme",
   themeSwitchedLight: "Switched to light theme",
+  serviceWorkerError: "Service worker error",
   testResults: "Test results",
   testResultsTime: "time",
   testResultsData: "data",

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -116,6 +116,7 @@ window.i18n.uk = {
   fullscreenDisabled: "Повноекранний режим вимкнено",
   themeSwitchedDark: "Переключено на темну тему",
   themeSwitchedLight: "Переключено на світлу тему",
+  serviceWorkerError: "Помилка Service Worker",
   testResults: "Результати тесту",
   testResultsTime: "час",
   testResultsData: "дані",


### PR DESCRIPTION
## Summary
- Display detailed service worker registration errors in notification with translation support.
- Add `serviceWorkerError` message to English and Ukrainian translation files.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689476131b5083298431a6972c3afc07