### PR TITLE
Handle non-string input in replaceSpacesWithUnderscore

### DIFF
--- a/js/replace_spaces_with_underscore.js
+++ b/js/replace_spaces_with_underscore.js
@@ -1,4 +1,5 @@
 function replaceSpacesWithUnderscore(str) {
+    if (typeof str !== 'string') return '';
     return str
         .replace(/\s+/g, '_')
         .replace(/[^\w-]/g, '');


### PR DESCRIPTION
## Summary
- safeguard replaceSpacesWithUnderscore from non-string input, returning empty string when necessary

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68947bb72e188329b05f0ba15e9125af