### PR TITLE
Fix duplicate announcements for roads without reference

### DIFF
--- a/js/road_change_announcer.js
+++ b/js/road_change_announcer.js
@@ -12,12 +12,16 @@ function announceRoadChange(road) {
     const currentNetwork = road.network || null;
 
     if (settings.voiceRoadChange) {
-        if (
-            !lastRoad.ref ||
+        const isInitial =
+            lastRoad.ref === null &&
+            lastRoad.name === null &&
+            lastRoad.network === null;
+        const hasChanged =
             lastRoad.ref !== currentRef ||
             lastRoad.name !== currentName ||
-            lastRoad.network !== currentNetwork
-        ) {
+            lastRoad.network !== currentNetwork;
+
+        if (isInitial || hasChanged) {
             const refPart = currentRef ? `${currentRef}` : '';
             const namePart = currentName ? `${currentName}` : '';
             const networkPart = currentNetwork ? `${currentNetwork}` : '';


### PR DESCRIPTION
## Summary
- avoid repeated road change announcements when a road lacks `ref`
- distinguish initial state from actual changes when announcing

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68948d711f8883299053dea9a5637c7e