### PR TITLE
Avoid double spaces in road change message

### DIFF
--- a/js/road_change_announcer.js
+++ b/js/road_change_announcer.js
@@ -25,7 +25,8 @@ function announceRoadChange(road) {
             const refPart = currentRef ? `${currentRef}` : '';
             const namePart = currentName ? `${currentName}` : '';
             const networkPart = currentNetwork ? `${currentNetwork}` : '';
-            speak(`Ви виїхали на дорогу ${refPart} ${namePart} ${networkPart}`.trim());
+            const parts = [refPart, namePart, networkPart].filter(part => part);
+            speak(['Ви виїхали на дорогу', ...parts].join(' '));
         }
     }
 


### PR DESCRIPTION
## Summary
- Avoid double spaces when announcing road changes by filtering and joining road parts before speaking.

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68948e36a91c8329ac4cd05d7ac9a4ed