### PR TITLE
Handle missing settings panel in toggleSettings

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -1,5 +1,9 @@
 function toggleSettings() {
     const panel = document.getElementById("settingsPanel");
+    if (!panel) {
+        console.warn("settingsPanel element not found");
+        return;
+    }
     const shouldOpen = !panel.classList.contains("active");
     panel.classList.toggle("active");
 


### PR DESCRIPTION
## Summary
- guard toggleSettings against missing settingsPanel element

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689493563dfc83299937cff577fa9efc