### PR TITLE
Scope settings lookups to panel

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -28,16 +28,22 @@ function loadSettingsFromStorage() {
 }
 
 function saveSettings() {
-    const soundAlerts = document.getElementById("soundAlerts");
-    const voiceAlerts = document.getElementById("voiceAlerts");
-    const voiceHromadaChange = document.getElementById("voiceHromadaChange");
-    const voiceRoadChange = document.getElementById("voiceRoadChange");
-    const showHromady = document.getElementById("showHromady");
-    const showInternationalRoads = document.getElementById("showInternationalRoads");
-    const showNationalRoads = document.getElementById("showNationalRoads");
-    const showRegionalRoads = document.getElementById("showRegionalRoads");
-    const showTerritorialRoads = document.getElementById("showTerritorialRoads");
-    const langSelect = document.getElementById("languageSelect");
+    const panel = document.getElementById("settingsPanel");
+    if (!panel) {
+        console.warn("settingsPanel element not found");
+        return;
+    }
+
+    const soundAlerts = panel.querySelector("#soundAlerts");
+    const voiceAlerts = panel.querySelector("#voiceAlerts");
+    const voiceHromadaChange = panel.querySelector("#voiceHromadaChange");
+    const voiceRoadChange = panel.querySelector("#voiceRoadChange");
+    const showHromady = panel.querySelector("#showHromady");
+    const showInternationalRoads = panel.querySelector("#showInternationalRoads");
+    const showNationalRoads = panel.querySelector("#showNationalRoads");
+    const showRegionalRoads = panel.querySelector("#showRegionalRoads");
+    const showTerritorialRoads = panel.querySelector("#showTerritorialRoads");
+    const langSelect = panel.querySelector("#languageSelect");
 
     if (soundAlerts) settings.soundAlerts = soundAlerts.checked; else console.warn("soundAlerts element not found");
     if (voiceAlerts) settings.voiceAlerts = voiceAlerts.checked; else console.warn("voiceAlerts element not found");
@@ -73,16 +79,22 @@ function saveSettings() {
 }
 
 function loadSettings() {
-    const soundAlerts = document.getElementById("soundAlerts");
-    const voiceAlerts = document.getElementById("voiceAlerts");
-    const voiceHromadaChange = document.getElementById("voiceHromadaChange");
-    const voiceRoadChange = document.getElementById("voiceRoadChange");
-    const showHromady = document.getElementById("showHromady");
-    const showInternationalRoads = document.getElementById("showInternationalRoads");
-    const showNationalRoads = document.getElementById("showNationalRoads");
-    const showRegionalRoads = document.getElementById("showRegionalRoads");
-    const showTerritorialRoads = document.getElementById("showTerritorialRoads");
-    const langSelect = document.getElementById("languageSelect");
+    const panel = document.getElementById("settingsPanel");
+    if (!panel) {
+        console.warn("settingsPanel element not found");
+        return;
+    }
+
+    const soundAlerts = panel.querySelector("#soundAlerts");
+    const voiceAlerts = panel.querySelector("#voiceAlerts");
+    const voiceHromadaChange = panel.querySelector("#voiceHromadaChange");
+    const voiceRoadChange = panel.querySelector("#voiceRoadChange");
+    const showHromady = panel.querySelector("#showHromady");
+    const showInternationalRoads = panel.querySelector("#showInternationalRoads");
+    const showNationalRoads = panel.querySelector("#showNationalRoads");
+    const showRegionalRoads = panel.querySelector("#showRegionalRoads");
+    const showTerritorialRoads = panel.querySelector("#showTerritorialRoads");
+    const langSelect = panel.querySelector("#languageSelect");
 
     if (soundAlerts) soundAlerts.checked = settings.soundAlerts; else console.warn("soundAlerts element not found");
     if (voiceAlerts) voiceAlerts.checked = settings.voiceAlerts; else console.warn("voiceAlerts element not found");


### PR DESCRIPTION
## Summary
- Limit settings save/load to elements within #settingsPanel
- Use panel.querySelector instead of document.getElementById for scoped DOM access

## Testing
- `node test_settings.js`

------
https://chatgpt.com/codex/tasks/task_e_68949c35dcd8832983ed58894b92c960