### PR TITLE
Check IndexedDB availability before opening storage

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -2,6 +2,9 @@ let db;
 
 function openDatabase() {
     if (db) return Promise.resolve(db);
+    if (!('indexedDB' in window)) {
+        return Promise.reject(new Error('IndexedDB is not supported in this environment'));
+    }
     return new Promise((resolve, reject) => {
         const request = indexedDB.open('gonettestDB', 1);
         request.onupgradeneeded = () => {


### PR DESCRIPTION
## Summary
- ensure storage initialization rejects when IndexedDB is unavailable

## Testing
- `npm test` *(fails: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6894a0d1756c8329a12c5da9f6ace3e8