### PR TITLE
Handle updateDatabaseInfo errors in saveSpeedDataToStorage

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -36,8 +36,14 @@ async function saveSpeedDataToStorage() {
 
     return new Promise((resolve, reject) => {
         tx.oncomplete = () => {
-            updateDatabaseInfo();
-            resolve();
+            try {
+                updateDatabaseInfo();
+            } catch (err) {
+                console.error(err);
+                reject(err);
+            } finally {
+                resolve();
+            }
         };
         tx.onerror = () => reject(tx.error);
     });


### PR DESCRIPTION
## Summary
- wrap `updateDatabaseInfo` in `try/catch`
- log and reject errors
- ensure `resolve()` always runs via `finally`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894a2b12e0c8329ad35f2a06b6da349