### PR TITLE
Ensure legacy data is array before migrating

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -70,9 +70,9 @@ async function loadSpeedDataFromStorage() {
         readTx.onerror = () => resolve({ values: [], keys: [], legacy: null });
     });
 
-    if (readResult.legacy !== undefined && readResult.legacy !== null) {
+    if (Array.isArray(readResult.legacy)) {
         // Migrate legacy array stored under 'records'
-        speedData = readResult.legacy || [];
+        speedData = readResult.legacy;
 
         const writeTx = database.transaction(STORAGE_KEY, 'readwrite');
         const writeStore = writeTx.objectStore(STORAGE_KEY);
@@ -84,6 +84,9 @@ async function loadSpeedDataFromStorage() {
             writeTx.onerror = resolve;
         });
     } else {
+        if (readResult.legacy !== undefined && readResult.legacy !== null) {
+            console.warn('Legacy data is not an array; skipping migration');
+        }
         // Build array from individual records
         const pairs = readResult.keys.map((key, idx) => ({
             key: Number(key),


### PR DESCRIPTION
## Summary
- check that `readResult.legacy` is an array before migration and warn if it's not

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894a4ed48c48329bb000b4ecf71deb2