### PR TITLE
fix: reject on migration write failure

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -79,9 +79,9 @@ async function loadSpeedDataFromStorage() {
         writeStore.clear();
         speedData.forEach((record, idx) => writeStore.put(record, idx));
 
-        await new Promise(resolve => {
+        await new Promise((resolve, reject) => {
             writeTx.oncomplete = resolve;
-            writeTx.onerror = resolve;
+            writeTx.onerror = () => reject(writeTx.error);
         });
     } else {
         if (readResult.legacy !== undefined && readResult.legacy !== null) {


### PR DESCRIPTION
## Summary
- reject speed data migration when IndexedDB write fails

## Testing
- `node --check js/storage.js`
- `node --check js/add_event_listener.js`


------
https://chatgpt.com/codex/tasks/task_e_6894a63a4fb8832983dbfe5cdd16f72b