### PR TITLE
Improve fullscreen handling

### DIFF
--- a/js/add_event_listener.js
+++ b/js/add_event_listener.js
@@ -26,12 +26,6 @@ window.addEventListener("DOMContentLoaded", async () => {
         lucide.createIcons({ strokeWidth: 1.5, class: 'h-6 w-6' });
     }
 
-    // Обробка виходу з повноекранного режиму
-    document.addEventListener("fullscreenchange", () => {
-        if (!document.fullscreenElement && isFullscreen) {
-            toggleFullscreen();
-        }
-    });
 });
 
 // Обробка зміни орієнтації для мобільних

--- a/js/toggle_fullscreen.js
+++ b/js/toggle_fullscreen.js
@@ -1,30 +1,54 @@
 function toggleFullscreen() {
     const body = document.body;
-    isFullscreen = !isFullscreen;
 
-    if (isFullscreen) {
-        body.classList.add("fullscreen-mode");
-        if (body.requestFullscreen) {
-            body.requestFullscreen();
-        } else if (document.documentElement.requestFullscreen) {
-            document.documentElement.requestFullscreen();
-        }
-        showNotification(t('fullscreenEnabled', 'Повноекранний режим увімкнено'));
-        setTimeout(() => {
-            if (speedChart) {
-                speedChart.resize();
-            }
-        }, ORIENTATION_DELAY);
+    if (!isFullscreen) {
+        const target = body.requestFullscreen ? body : document.documentElement;
+        target.requestFullscreen()
+            .then(() => {
+                isFullscreen = true;
+                body.classList.add("fullscreen-mode");
+                showNotification(t('fullscreenEnabled', 'Повноекранний режим увімкнено'));
+                setTimeout(() => {
+                    if (speedChart) {
+                        speedChart.resize();
+                    }
+                }, ORIENTATION_DELAY);
+            })
+            .catch((err) => {
+                isFullscreen = false;
+                showNotification(t('fullscreenEnableFailed', 'Не вдалося увімкнути повноекранний режим'));
+                console.error('Failed to enter fullscreen', err);
+            });
     } else {
-        body.classList.remove("fullscreen-mode");
-        if (document.exitFullscreen) {
-            document.exitFullscreen();
-        }
-        showNotification(t('fullscreenDisabled', 'Повноекранний режим вимкнено'));
+        document.exitFullscreen()
+            .then(() => {
+                isFullscreen = false;
+                body.classList.remove("fullscreen-mode");
+                showNotification(t('fullscreenDisabled', 'Повноекранний режим вимкнено'));
+                setTimeout(() => {
+                    if (speedChart) {
+                        speedChart.resize();
+                    }
+                }, ORIENTATION_DELAY);
+            })
+            .catch((err) => {
+                isFullscreen = true;
+                showNotification(t('fullscreenDisableFailed', 'Не вдалося вимкнути повноекранний режим'));
+                console.error('Failed to exit fullscreen', err);
+            });
+    }
+}
+
+// Sync isFullscreen with actual fullscreen state
+document.addEventListener('fullscreenchange', () => {
+    const fullscreen = !!document.fullscreenElement;
+    if (fullscreen !== isFullscreen) {
+        isFullscreen = fullscreen;
+        document.body.classList.toggle('fullscreen-mode', fullscreen);
         setTimeout(() => {
             if (speedChart) {
                 speedChart.resize();
             }
         }, ORIENTATION_DELAY);
     }
-}
+});


### PR DESCRIPTION
## Summary
- toggle fullscreen only after `requestFullscreen`/`exitFullscreen` resolves
- add error handling to reset `isFullscreen` and notify the user
- sync fullscreen state via `fullscreenchange` listener and remove old handler

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894ad6538b88329a30fe5b9cb2b6d83