### PR TITLE
refactor: centralize delayed chart resize helper

### DIFF
--- a/js/toggle_fullscreen.js
+++ b/js/toggle_fullscreen.js
@@ -1,3 +1,11 @@
+function resizeChartDelayed() {
+    setTimeout(() => {
+        if (speedChart) {
+            speedChart.resize();
+        }
+    }, ORIENTATION_DELAY);
+}
+
 function toggleFullscreen() {
     const body = document.body;
 
@@ -15,11 +23,7 @@ function toggleFullscreen() {
                 isFullscreen = true;
                 body.classList.add("fullscreen-mode");
                 showNotification(t('fullscreenEnabled', 'Повноекранний режим увімкнено'));
-                setTimeout(() => {
-                    if (speedChart) {
-                        speedChart.resize();
-                    }
-                }, ORIENTATION_DELAY);
+                resizeChartDelayed();
             })
             .catch((err) => {
                 isFullscreen = false;
@@ -39,11 +43,7 @@ function toggleFullscreen() {
                 isFullscreen = false;
                 body.classList.remove("fullscreen-mode");
                 showNotification(t('fullscreenDisabled', 'Повноекранний режим вимкнено'));
-                setTimeout(() => {
-                    if (speedChart) {
-                        speedChart.resize();
-                    }
-                }, ORIENTATION_DELAY);
+                resizeChartDelayed();
             })
             .catch((err) => {
                 isFullscreen = true;
@@ -59,10 +59,6 @@ document.addEventListener('fullscreenchange', () => {
     if (fullscreen !== isFullscreen) {
         isFullscreen = fullscreen;
         document.body.classList.toggle('fullscreen-mode', fullscreen);
-        setTimeout(() => {
-            if (speedChart) {
-                speedChart.resize();
-            }
-        }, ORIENTATION_DELAY);
+        resizeChartDelayed();
     }
 });


### PR DESCRIPTION
## Summary
- add reusable `resizeChartDelayed` helper for chart resizing
- use helper in fullscreen toggle and fullscreen change handlers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894b27ba4d48329b6aa97c4b10c7c9e