### PR TITLE
fix: robust GPS coordinate checks

### DIFF
--- a/js/update_GPS_info.js
+++ b/js/update_GPS_info.js
@@ -12,7 +12,10 @@ function updateGPSInfo() {
     const naText = t('naValue', 'N/A');
     const directions = t('directionLabels', DEFAULT_DIRECTION_LABELS[currentLang]);
 
-    if (currentGPSData.latitude && currentGPSData.longitude) {
+    if (
+        Number.isFinite(currentGPSData.latitude) &&
+        Number.isFinite(currentGPSData.longitude)
+    ) {
         gpsStatusEl.textContent = t('gpsActive', 'Активний');
         gpsStatusEl.classList.remove('status-warning', 'status-success', 'status-accent');
         gpsStatusEl.classList.add('status-accent');
@@ -67,7 +70,10 @@ function updateGPSInfo() {
         }
 
         // Відстань від попередньої точки
-        if (lastSavedGPSData.latitude && lastSavedGPSData.longitude) {
+        if (
+            Number.isFinite(lastSavedGPSData.latitude) &&
+            Number.isFinite(lastSavedGPSData.longitude)
+        ) {
             const distance = calculateDistance(
                 lastSavedGPSData.latitude,
                 lastSavedGPSData.longitude,
@@ -113,7 +119,10 @@ async function updateAdminInfo() {
     const raionEl = document.getElementById('raion');
     const hromadaEl = document.getElementById('hromada');
 
-    if (!currentGPSData.latitude || !currentGPSData.longitude) {
+    if (
+        !Number.isFinite(currentGPSData.latitude) ||
+        !Number.isFinite(currentGPSData.longitude)
+    ) {
         oblastEl.textContent = '-';
         raionEl.textContent = '-';
         hromadaEl.textContent = '-';
@@ -149,7 +158,10 @@ async function updateRoadInfo() {
     const distEl = document.getElementById('roadDistance');
     const networkEl = document.getElementById('roadNetwork');
 
-    if (!currentGPSData.latitude || !currentGPSData.longitude) {
+    if (
+        !Number.isFinite(currentGPSData.latitude) ||
+        !Number.isFinite(currentGPSData.longitude)
+    ) {
         refEl.textContent = '-';
         nameEl.textContent = '-';
         distEl.textContent = '-';


### PR DESCRIPTION
## Summary
- use `Number.isFinite` for GPS coordinate validation instead of relying on truthiness
- handle missing coordinates consistently in admin and road lookups

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894b92111648329b82352ba5ae176d3