### PR TITLE
Handle zero GPS accuracy display

### DIFF
--- a/js/update_GPS_info.js
+++ b/js/update_GPS_info.js
@@ -24,7 +24,7 @@ function updateGPSInfo() {
         )}, ${currentGPSData.longitude.toFixed(6)}`;
 
         // Точність
-        if (currentGPSData.accuracy) {
+        if (currentGPSData.accuracy != null) {
             gpsAccuracyEl.textContent = `±${currentGPSData.accuracy.toFixed(
                 1
             )}`;


### PR DESCRIPTION
## Summary
- Ensure GPS accuracy field renders when the value is 0 by treating `0` as a valid accuracy

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894bccfc100832987870adcc8ea9b58