### PR TITLE
Use Number.isFinite for GPS readings

### DIFF
--- a/js/update_GPS_info.js
+++ b/js/update_GPS_info.js
@@ -41,7 +41,7 @@ function updateGPSInfo() {
         }
 
         // Висота
-        if (currentGPSData.altitude !== null) {
+        if (Number.isFinite(currentGPSData.altitude)) {
             altitudeInfoEl.textContent = `${currentGPSData.altitude.toFixed(
                 1
             )}`;
@@ -50,7 +50,7 @@ function updateGPSInfo() {
         }
 
         // GPS швидкість
-        if (currentGPSData.speed !== null && currentGPSData.speed > 0) {
+        if (Number.isFinite(currentGPSData.speed) && currentGPSData.speed > 0) {
             gpsSpeedInfoEl.textContent = `${(
                 currentGPSData.speed * 3.6
             ).toFixed(1)}`;
@@ -59,7 +59,7 @@ function updateGPSInfo() {
         }
 
         // Напрямок
-        if (currentGPSData.heading !== null) {
+        if (Number.isFinite(currentGPSData.heading)) {
             const directionIndex =
                 Math.round(currentGPSData.heading / 45) % directions.length;
             headingInfoEl.textContent = `${currentGPSData.heading.toFixed(


### PR DESCRIPTION
## Summary
- validate altitude, speed, and heading using `Number.isFinite`
- display `naText` fallback when GPS metrics are not valid numbers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894be77c83c83299993dddc7b6c6531