### PR TITLE
Clear accuracy styles when GPS data missing

### DIFF
--- a/js/update_GPS_info.js
+++ b/js/update_GPS_info.js
@@ -37,6 +37,7 @@ function updateGPSInfo() {
                 gpsAccuracyEl.classList.add('status-warning');
             }
         } else {
+            gpsAccuracyEl.classList.remove('status-warning', 'status-success', 'status-accent');
             gpsAccuracyEl.textContent = naText;
         }
 


### PR DESCRIPTION
## Summary
- reset GPS accuracy element styles when accuracy data is unavailable

## Testing
- `node /tmp/gps_test.js`

------
https://chatgpt.com/codex/tasks/task_e_6894bf5584108329b8490f8840765828