### PR TITLE
Handle errors in updateGPSInfo

### DIFF
--- a/js/update_GPS_info.js
+++ b/js/update_GPS_info.js
@@ -111,8 +111,8 @@ function updateGPSInfo() {
         headingInfoEl.textContent = naText;
     }
 
-    updateAdminInfo();
-    updateRoadInfo();
+    void updateAdminInfo().catch(console.error);
+    void updateRoadInfo().catch(console.error);
 }
 
 async function updateAdminInfo() {


### PR DESCRIPTION
## Summary
- add error logging for updateAdminInfo and updateRoadInfo promises to avoid silent rejections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c0a770d88329b9d14fb83988014a