### PR TITLE
Use elapsed time for speed calculation in updateUI

### DIFF
--- a/js/update_UI.js
+++ b/js/update_UI.js
@@ -1,9 +1,15 @@
+let lastUpdateTime = Date.now();
+
 function updateUI() {
     const now = Date.now();
+    const deltaTime = (now - lastUpdateTime) / 1000;
     const elapsed = (now - startTime) / 1000;
     const delta = totalBytes - prevBytes;
     prevBytes = totalBytes;
-    const speedMbps = (delta * 8) / (1024 * 1024);
+    const speedMbps =
+        deltaTime > 0 ? (delta * 8) / (1024 * 1024 * deltaTime) : 0;
+
+    lastUpdateTime = now;
 
     currentSpeedMbps = speedMbps;
 


### PR DESCRIPTION
## Summary
- track last update time to compute elapsed time between UI refreshes
- derive download speed using delta time

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c2c9f1a4832991354f4bf980bfd9