### PR TITLE
Streamline speed updates

### DIFF
--- a/js/speed_test.js
+++ b/js/speed_test.js
@@ -160,10 +160,8 @@ async function runTest() {
         if (!testActive) break;
       }
 
-      const { speedMbps } = await measureDownloadSpeed();
+      await measureDownloadSpeed();
       consecutiveErrors = 0;
-      currentSpeedMbps = speedMbps;
-      updateStats();
     } catch (e) {
       if (e.name === 'AbortError' && !testActive) {
         break;

--- a/js/update_UI.js
+++ b/js/update_UI.js
@@ -1,21 +1,10 @@
-let lastUpdateTime = Date.now();
-
 function updateUI() {
     const now = Date.now();
-    const deltaTime = (now - lastUpdateTime) / 1000;
     const elapsed = (now - startTime) / 1000;
-    const delta = totalBytes - prevBytes;
-    prevBytes = totalBytes;
-    const speedMbps =
-        deltaTime > 0 ? (delta * 8) / (1024 * 1024 * deltaTime) : 0;
-
-    lastUpdateTime = now;
-
-    currentSpeedMbps = speedMbps;
 
     if (isConnected) {
         document.getElementById("speedValue").textContent =
-            speedMbps.toFixed(2);
+            currentSpeedMbps.toFixed(2);
         document.getElementById("status").textContent = t('statusActive', 'Тест активний');
 
         // Ховаємо індикатор помилки
@@ -26,6 +15,4 @@ function updateUI() {
     document.getElementById("timeValue").textContent = formatSeconds(Math.floor(elapsed));
 
     updateGPSInfo();
-    updateChart();
-    updateStats();
 }


### PR DESCRIPTION
## Summary
- Remove speed and statistics calculations from UI updater
- Let measure loop only trigger per-second speed updates

## Testing
- `npm test` *(fails: package.json missing)*
- `npm run lint` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6894c3a638a88329ad6f609dd570ec9c