### PR TITLE
refactor: cache DOM elements in UI update

### DIFF
--- a/js/update_UI.js
+++ b/js/update_UI.js
@@ -2,17 +2,46 @@ function updateUI() {
     const now = Date.now();
     const elapsed = (now - startTime) / 1000;
 
-    if (isConnected) {
-        document.getElementById("speedValue").textContent =
-            currentSpeedMbps.toFixed(2);
-        document.getElementById("status").textContent = t('statusActive', 'Тест активний');
-
-        // Ховаємо індикатор помилки
-        document.getElementById("alertIndicator").style.display = "none";
+    const speedValueEl = document.getElementById("speedValue");
+    if (!speedValueEl) {
+        console.error("Element 'speedValue' not found");
+        return;
     }
 
-    document.getElementById("downloadedValue").textContent = formatDownloaded(totalBytes);
-    document.getElementById("timeValue").textContent = formatSeconds(Math.floor(elapsed));
+    const statusEl = document.getElementById("status");
+    if (!statusEl) {
+        console.error("Element 'status' not found");
+        return;
+    }
+
+    const alertIndicatorEl = document.getElementById("alertIndicator");
+    if (!alertIndicatorEl) {
+        console.error("Element 'alertIndicator' not found");
+        return;
+    }
+
+    const downloadedValueEl = document.getElementById("downloadedValue");
+    if (!downloadedValueEl) {
+        console.error("Element 'downloadedValue' not found");
+        return;
+    }
+
+    const timeValueEl = document.getElementById("timeValue");
+    if (!timeValueEl) {
+        console.error("Element 'timeValue' not found");
+        return;
+    }
+
+    if (isConnected) {
+        speedValueEl.textContent = currentSpeedMbps.toFixed(2);
+        statusEl.textContent = t('statusActive', 'Тест активний');
+
+        // Ховаємо індикатор помилки
+        alertIndicatorEl.style.display = "none";
+    }
+
+    downloadedValueEl.textContent = formatDownloaded(totalBytes);
+    timeValueEl.textContent = formatSeconds(Math.floor(elapsed));
 
     updateGPSInfo();
 }


### PR DESCRIPTION
## Summary
- cache DOM elements in `updateUI` and verify they exist
- guard property usage with null checks for `speedValue`, `status`, `alertIndicator`, `downloadedValue`, and `timeValue`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c4b9955c832981587f319499ea87