### PR TITLE
Localize distance label in admin stats

### DIFF
--- a/js/update_admin_stats.js
+++ b/js/update_admin_stats.js
@@ -104,7 +104,7 @@ function updateAdminStats() {
         ).toFixed(1);
         return (
             countRows(obj, indent) +
-            `<div class="info-row" style="--indent:${indent}px"><span>Відстань (км)</span><span>${totalKm}</span></div>` +
+            `<div class="info-row" style="--indent:${indent}px"><span>${t('distanceKmLabel', 'Відстань (км)')}</span><span>${totalKm}</span></div>` +
             distRows(obj, indent)
         );
     };

--- a/translations/en.js
+++ b/translations/en.js
@@ -62,6 +62,7 @@ window.i18n.en = {
   zeroSpeedLabel: "0 Mbps:",
   upTo2SpeedLabel: "Up to 2 Mbps:",
   above2SpeedLabel: "Above 2 Mbps:",
+  distanceKmLabel: "Distance (km)",
   timeColumn: "Time",
   speedColumn: "Download speed Mbps",
   latColumn: "Latitude",

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -62,6 +62,7 @@ window.i18n.uk = {
   zeroSpeedLabel: "0 Мбіт/с:",
   upTo2SpeedLabel: "До 2 Мбіт/с:",
   above2SpeedLabel: "Більше 2 Мбіт/с:",
+  distanceKmLabel: "Відстань (км)",
   timeColumn: "Час",
   speedColumn: "Швидкість завантаження Мбіт/с",
   latColumn: "Широта",


### PR DESCRIPTION
## Summary
- Use `t('distanceKmLabel')` to translate the distance label in admin statistics
- Add English and Ukrainian `distanceKmLabel` translations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894d24c51b083298e297153e935ea89