### PR TITLE
Add null check for data display element

### DIFF
--- a/js/update_data_display.js
+++ b/js/update_data_display.js
@@ -1,5 +1,7 @@
 function updateDataDisplay() {
     const dataDisplay = document.getElementById("dataDisplay");
+    if (!dataDisplay) return;
+
     const lastRecords = speedData.slice(-10).reverse();
 
     if (lastRecords.length === 0) {


### PR DESCRIPTION
## Summary
- Guard `updateDataDisplay` against a missing `dataDisplay` element to avoid runtime errors.

## Testing
- `node --check js/update_data_display.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894d735f57083298d4376d30441d172