### PR TITLE
fix: display N/A for missing GPS metrics

### DIFF
--- a/js/update_data_display.js
+++ b/js/update_data_display.js
@@ -16,10 +16,10 @@ function updateDataDisplay() {
                 <div class="data-row">
                     <div>${record.timestamp}</div>
                     <div>${record.speed.toFixed(2)}</div>
-                    <div>${record.latitude ? record.latitude.toFixed(6) : "N/A"}</div>
-                    <div>${record.longitude ? record.longitude.toFixed(6) : "N/A"}</div>
-                    <div>${record.altitude ? record.altitude.toFixed(1) : "N/A"}</div>
-                    <div>${record.gpsSpeed ? record.gpsSpeed.toFixed(1) : "N/A"}</div>
+                    <div>${record.latitude != null ? record.latitude.toFixed(6) : "N/A"}</div>
+                    <div>${record.longitude != null ? record.longitude.toFixed(6) : "N/A"}</div>
+                    <div>${record.altitude != null ? record.altitude.toFixed(1) : "N/A"}</div>
+                    <div>${record.gpsSpeed != null ? record.gpsSpeed.toFixed(1) : "N/A"}</div>
                     <div>${record.distance !== undefined ? record.distance.toFixed(1) : "N/A"}</div>
                     <div>${record.region || 'N/A'}</div>
                     <div>${record.rayon || 'N/A'}</div>


### PR DESCRIPTION
## Summary
- replace truthy checks with explicit null checks for latitude, longitude, altitude, and GPS speed values in the data display

## Testing
- `node --check js/update_data_display.js`
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894d87a373883299c7a2b834cf2b926