### PR TITLE
Refactor updateDataDisplay to build DOM nodes

### DIFF
--- a/js/update_data_display.js
+++ b/js/update_data_display.js
@@ -4,29 +4,73 @@ function updateDataDisplay() {
 
     const lastRecords = speedData.slice(-10).reverse();
 
+    dataDisplay.textContent = "";
+
     if (lastRecords.length === 0) {
-        dataDisplay.innerHTML =
-            `<div class="placeholder">${t('noData', 'Немає даних')}</div>`;
+        const placeholder = document.createElement("div");
+        placeholder.className = "placeholder";
+        placeholder.textContent = t("noData", "Немає даних");
+        dataDisplay.appendChild(placeholder);
         return;
     }
 
-    dataDisplay.innerHTML = lastRecords
-        .map(
-            (record) => `
-                <div class="data-row">
-                    <div>${record.timestamp}</div>
-                    <div>${record.speed.toFixed(2)}</div>
-                    <div>${record.latitude != null ? record.latitude.toFixed(6) : "N/A"}</div>
-                    <div>${record.longitude != null ? record.longitude.toFixed(6) : "N/A"}</div>
-                    <div>${record.altitude != null ? record.altitude.toFixed(1) : "N/A"}</div>
-                    <div>${record.gpsSpeed != null ? record.gpsSpeed.toFixed(1) : "N/A"}</div>
-                    <div>${record.distance !== undefined ? record.distance.toFixed(1) : "N/A"}</div>
-                    <div>${record.region || 'N/A'}</div>
-                    <div>${record.rayon || 'N/A'}</div>
-                    <div>${record.hromada || 'N/A'}</div>
-                    <div>${record.roadRef || 'N/A'}</div>
-                </div>
-            `
-        )
-        .join("");
+    const fragment = document.createDocumentFragment();
+
+    lastRecords.forEach((record) => {
+        const row = document.createElement("div");
+        row.className = "data-row";
+
+        const timestamp = document.createElement("div");
+        timestamp.textContent = record.timestamp;
+        row.appendChild(timestamp);
+
+        const speed = document.createElement("div");
+        speed.textContent = record.speed.toFixed(2);
+        row.appendChild(speed);
+
+        const latitude = document.createElement("div");
+        latitude.textContent =
+            record.latitude != null ? record.latitude.toFixed(6) : "N/A";
+        row.appendChild(latitude);
+
+        const longitude = document.createElement("div");
+        longitude.textContent =
+            record.longitude != null ? record.longitude.toFixed(6) : "N/A";
+        row.appendChild(longitude);
+
+        const altitude = document.createElement("div");
+        altitude.textContent =
+            record.altitude != null ? record.altitude.toFixed(1) : "N/A";
+        row.appendChild(altitude);
+
+        const gpsSpeed = document.createElement("div");
+        gpsSpeed.textContent =
+            record.gpsSpeed != null ? record.gpsSpeed.toFixed(1) : "N/A";
+        row.appendChild(gpsSpeed);
+
+        const distance = document.createElement("div");
+        distance.textContent =
+            record.distance !== undefined ? record.distance.toFixed(1) : "N/A";
+        row.appendChild(distance);
+
+        const region = document.createElement("div");
+        region.textContent = record.region || "N/A";
+        row.appendChild(region);
+
+        const rayon = document.createElement("div");
+        rayon.textContent = record.rayon || "N/A";
+        row.appendChild(rayon);
+
+        const hromada = document.createElement("div");
+        hromada.textContent = record.hromada || "N/A";
+        row.appendChild(hromada);
+
+        const roadRef = document.createElement("div");
+        roadRef.textContent = record.roadRef || "N/A";
+        row.appendChild(roadRef);
+
+        fragment.appendChild(row);
+    });
+
+    dataDisplay.appendChild(fragment);
 }


### PR DESCRIPTION
## Summary
- Replace string-built HTML with DOM node creation in `updateDataDisplay`
- Use `DocumentFragment` and `textContent` for safe, efficient rendering

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894da16898c8329aa5b531fe855113e