### PR TITLE
Log storage API errors

### DIFF
--- a/js/update_database_info.js
+++ b/js/update_database_info.js
@@ -9,7 +9,7 @@ function initStorageQuota() {
             .then(({ quota }) => {
                 if (quota) window.cachedQuota = quota;
             })
-            .catch(() => {});
+            .catch(err => console.error('Storage estimate failed', err));
     } else if (
         navigator.webkitTemporaryStorage &&
         navigator.webkitTemporaryStorage.queryUsageAndQuota
@@ -18,7 +18,7 @@ function initStorageQuota() {
             (_usage, quota) => {
                 if (quota) window.cachedQuota = quota;
             },
-            () => {}
+            (err) => console.error('Quota query failed', err)
         );
     }
 }


### PR DESCRIPTION
## Summary
- Log storage estimation failures in `initStorageQuota`
- Print errors from `queryUsageAndQuota`

## Testing
- `node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const context = { console, window:{}, navigator: { storage: { estimate: () => Promise.reject('fail!') } } };
vm.createContext(context);
vm.runInContext(fs.readFileSync('./js/update_database_info.js','utf8'), context);
context.initStorageQuota();
setTimeout(()=>{},100);
NODE`
- `node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const context = { console, window:{}, navigator: { webkitTemporaryStorage: { queryUsageAndQuota: (success, error) => error('failQuota') } } };
vm.createContext(context);
vm.runInContext(fs.readFileSync('./js/update_database_info.js','utf8'), context);
context.initStorageQuota();
setTimeout(()=>{},100);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_6894de3a71cc83298b40f10f7205b63f