### PR TITLE
Recompute cached local storage size when data changes

### DIFF
--- a/js/update_database_info.js
+++ b/js/update_database_info.js
@@ -1,5 +1,6 @@
 window.cachedDataSize = 0;
 window.cachedDataLength = 0;
+window.cachedDataJSON = '';
 window.cachedQuota = 0;
 
 function initStorageQuota() {
@@ -78,9 +79,14 @@ function updateDatabaseInfo() {
 }
 
 function estimateLocalStorageSize() {
-    if (window.cachedDataLength !== speedData.length) {
-        window.cachedDataSize = new Blob([JSON.stringify(speedData)]).size;
+    const dataJSON = JSON.stringify(speedData);
+    if (
+        window.cachedDataLength !== speedData.length ||
+        window.cachedDataJSON !== dataJSON
+    ) {
+        window.cachedDataSize = new Blob([dataJSON]).size;
         window.cachedDataLength = speedData.length;
+        window.cachedDataJSON = dataJSON;
     }
     return window.cachedDataSize;
 }


### PR DESCRIPTION
## Summary
- Track last serialized speedData to detect changes beyond length
- Recalculate cachedDataSize only when the data content changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894df7b1b808329b7c51f61fef4e442