### PR TITLE
Reset storage threshold state after data cleanup

### DIFF
--- a/js/clear_data.js
+++ b/js/clear_data.js
@@ -25,6 +25,7 @@ function clearData() {
             if (greenCluster) greenCluster.clearLayers();
             mapMarkers = [];
         }
+        window.lastStoragePercent = 0;
         updateDataDisplay();
         updateDatabaseInfo();
         updateGPSInfo();

--- a/js/update_database_info.js
+++ b/js/update_database_info.js
@@ -94,6 +94,9 @@ function estimateLocalStorageSize() {
 function notifyStorageThreshold(percent) {
     const thresholds = [50, 90, 95, 99];
     window.lastStoragePercent = window.lastStoragePercent || 0;
+    if (percent < window.lastStoragePercent) {
+        window.lastStoragePercent = percent;
+    }
     thresholds.forEach(th => {
         if (percent >= th && window.lastStoragePercent < th) {
             showNotification(


### PR DESCRIPTION
## Summary
- Ensure notifyStorageThreshold resets lastStoragePercent if storage usage drops
- Reset lastStoragePercent to 0 when clearing data so storage warnings reappear

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894e0347b5483299371b1fc8c282896