### PR TITLE
Fix typo in road stats label

### DIFF
--- a/js/update_road_stats.js
+++ b/js/update_road_stats.js
@@ -79,7 +79,7 @@ function updateRoadStats() {
             `<div class="info-row"><span>${t('zeroSpeedLabel', '0 Мбіт/с:')}</span><span>${s.zero} (${zp}%)</span></div>` +
             `<div class="info-row"><span>${t('upTo2SpeedLabel', 'До 2 Мбіт/с:')}</span><span>${s.upto2} (${up}%)</span></div>` +
             `<div class="info-row"><span>${t('above2SpeedLabel', 'Більше 2 Мбіт/с:')}</span><span>${s.above2} (${ap}%)</span></div>` +
-            `<div class="info-row"><span>Відстань (% від загальної протяжності дорги)</span><span>${roadLenStr}</span></div>` +
+            `<div class="info-row"><span>Відстань (% від загальної протяжності дороги)</span><span>${roadLenStr}</span></div>` +
             `<div class="info-row"><span>${t('zeroSpeedLabel','0 Мбіт/с:')}</span><span>${zKm.toFixed(1)} (${zl}%)</span></div>` +
             `<div class="info-row"><span>${t('upTo2SpeedLabel','До 2 Мбіт/с:')}</span><span>${uKm.toFixed(1)} (${ul}%)</span></div>` +
             `<div class="info-row"><span>${t('above2SpeedLabel','Більше 2 Мбіт/с:')}</span><span>${aKm.toFixed(1)} (${al}%)</span></div>` +


### PR DESCRIPTION
## Summary
- fix typo in road distance percentage label

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node --check js/update_road_stats.js`


------
https://chatgpt.com/codex/tasks/task_e_6894e7040f4c83299841c1ba0ff73cb5