### PR TITLE
i18n: translate road stats labels

### DIFF
--- a/js/update_road_stats.js
+++ b/js/update_road_stats.js
@@ -75,11 +75,11 @@ function updateRoadStats() {
         rows.push(
             `<div class="info-row road-toggle" data-target="${roadId}"><span><i data-lucide="plus"></i> ${road}</span><span>${s.total} (${lenStr})</span></div>` +
             `<div id="${roadId}" class="road-content hidden" style="padding-left:20px">` +
-            `<div class="info-row"><span>Тестів (% від загальної кількості)</span></div>` +
+            `<div class="info-row"><span>${t('testsPercentTotal', 'Тестів (% від загальної кількості)')}</span></div>` +
             `<div class="info-row"><span>${t('zeroSpeedLabel', '0 Мбіт/с:')}</span><span>${s.zero} (${zp}%)</span></div>` +
             `<div class="info-row"><span>${t('upTo2SpeedLabel', 'До 2 Мбіт/с:')}</span><span>${s.upto2} (${up}%)</span></div>` +
             `<div class="info-row"><span>${t('above2SpeedLabel', 'Більше 2 Мбіт/с:')}</span><span>${s.above2} (${ap}%)</span></div>` +
-            `<div class="info-row"><span>Відстань (% від загальної протяжності дороги)</span><span>${roadLenStr}</span></div>` +
+            `<div class="info-row"><span>${t('distancePercentRoad', 'Відстань (% від загальної протяжності дороги)')}</span><span>${roadLenStr}</span></div>` +
             `<div class="info-row"><span>${t('zeroSpeedLabel','0 Мбіт/с:')}</span><span>${zKm.toFixed(1)} (${zl}%)</span></div>` +
             `<div class="info-row"><span>${t('upTo2SpeedLabel','До 2 Мбіт/с:')}</span><span>${uKm.toFixed(1)} (${ul}%)</span></div>` +
             `<div class="info-row"><span>${t('above2SpeedLabel','Більше 2 Мбіт/с:')}</span><span>${aKm.toFixed(1)} (${al}%)</span></div>` +

--- a/translations/en.js
+++ b/translations/en.js
@@ -62,6 +62,8 @@ window.i18n.en = {
   zeroSpeedLabel: "0 Mbps:",
   upTo2SpeedLabel: "Up to 2 Mbps:",
   above2SpeedLabel: "Above 2 Mbps:",
+  testsPercentTotal: "Tests (% of total)",
+  distancePercentRoad: "Distance (% of total road length)",
   distanceKmLabel: "Distance (km)",
   timeColumn: "Time",
   speedColumn: "Download speed Mbps",

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -62,6 +62,8 @@ window.i18n.uk = {
   zeroSpeedLabel: "0 Мбіт/с:",
   upTo2SpeedLabel: "До 2 Мбіт/с:",
   above2SpeedLabel: "Більше 2 Мбіт/с:",
+  testsPercentTotal: "Тестів (% від загальної кількості)",
+  distancePercentRoad: "Відстань (% від загальної протяжності дороги)",
   distanceKmLabel: "Відстань (км)",
   timeColumn: "Час",
   speedColumn: "Швидкість завантаження Мбіт/с",


### PR DESCRIPTION
## Summary
- localize road statistics headers using translation function
- add English and Ukrainian strings for new labels

## Testing
- `node - <<'NODE' ... NODE`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894e7b7041c83299141331778c28b02