### PR TITLE
Skip invalid speed entries when computing distribution

### DIFF
--- a/js/update_speed_distribution.js
+++ b/js/update_speed_distribution.js
@@ -1,11 +1,16 @@
 function updateSpeedDistribution() {
-    const total = speedData.length;
-    let zero = 0,
+    let total = 0,
+        zero = 0,
         upTo2 = 0;
     for (const rec of speedData) {
-        if (rec.speed === 0) {
+        const speed = rec.speed;
+        if (typeof speed !== "number" || speed < 0 || Number.isNaN(speed)) {
+            continue;
+        }
+        total++;
+        if (speed === 0) {
             zero++;
-        } else if (rec.speed > 0 && rec.speed <= 2) {
+        } else if (speed > 0 && speed <= 2) {
             upTo2++;
         }
     }


### PR DESCRIPTION
## Summary
- Ignore speed records that are not numbers, are negative, or are NaN
- Count only valid speed records when computing distribution statistics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894ec22cabc83299f1679e1f9e96822