### PR TITLE
Track speeds above 2 m/s in speed distribution

### DIFF
--- a/js/update_speed_distribution.js
+++ b/js/update_speed_distribution.js
@@ -1,7 +1,8 @@
 function updateSpeedDistribution() {
     let total = 0,
         zero = 0,
-        upTo2 = 0;
+        upTo2 = 0,
+        above2 = 0;
     for (const rec of speedData) {
         const speed = rec.speed;
         if (typeof speed !== "number" || speed < 0 || Number.isNaN(speed)) {
@@ -12,9 +13,10 @@ function updateSpeedDistribution() {
             zero++;
         } else if (speed > 0 && speed <= 2) {
             upTo2++;
+        } else if (speed > 2) {
+            above2++;
         }
     }
-    const above2 = total - zero - upTo2;
 
     const set = (id, count) => {
         const el = document.getElementById(id);


### PR DESCRIPTION
## Summary
- Count speed measurements above 2 m/s during speed distribution update instead of deriving the value after the loop

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894ed93535883298df443c4a1311159