### PR TITLE
Cache speed stat elements and check for null

### DIFF
--- a/js/update_stats.js
+++ b/js/update_stats.js
@@ -1,3 +1,7 @@
+const avgSpeedEl = document.getElementById("avgSpeed");
+const maxSpeedEl = document.getElementById("maxSpeed");
+const minSpeedEl = document.getElementById("minSpeed");
+
 function updateStats() {
     if (currentSpeedMbps > 0) {
         speedStats.min = Math.min(speedStats.min, currentSpeedMbps);
@@ -7,16 +11,18 @@ function updateStats() {
 
         const avg = speedStats.sum / speedStats.count;
 
-        document.getElementById("avgSpeed").textContent = `${avg.toFixed(
-            2
-        )}`;
-        document.getElementById(
-            "maxSpeed"
-        ).textContent = `${speedStats.max.toFixed(2)}`;
-        document.getElementById("minSpeed").textContent =
-            speedStats.min === Infinity
-                ? "0.00"
-                : `${speedStats.min.toFixed(2)}`;
+        if (avgSpeedEl) {
+            avgSpeedEl.textContent = `${avg.toFixed(2)}`;
+        }
+        if (maxSpeedEl) {
+            maxSpeedEl.textContent = `${speedStats.max.toFixed(2)}`;
+        }
+        if (minSpeedEl) {
+            minSpeedEl.textContent =
+                speedStats.min === Infinity
+                    ? "0.00"
+                    : `${speedStats.min.toFixed(2)}`;
+        }
 
         // Перевірка порогу швидкості
         if (currentSpeedMbps < settings.speedThreshold && isConnected) {
@@ -31,3 +37,4 @@ function updateStats() {
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- cache DOM references for avgSpeed, maxSpeed, minSpeed
- guard textContent updates by verifying the elements exist

## Testing
- `node --check js/update_stats.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894efc5026883299e9caccc30fe659c