### PR TITLE
Include zero speeds in statistics

### DIFF
--- a/js/update_stats.js
+++ b/js/update_stats.js
@@ -3,7 +3,8 @@ const maxSpeedEl = document.getElementById("maxSpeed");
 const minSpeedEl = document.getElementById("minSpeed");
 
 function updateStats() {
-    if (currentSpeedMbps > 0) {
+    // Include zero speeds so periods of complete outage affect statistics
+    if (currentSpeedMbps >= 0) {
         speedStats.min = Math.min(speedStats.min, currentSpeedMbps);
         speedStats.max = Math.max(speedStats.max, currentSpeedMbps);
         speedStats.sum += currentSpeedMbps;


### PR DESCRIPTION
## Summary
- include zero measurements in download speed statistics to reflect complete outages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f0ece8ec832996ed337d9185295e