### PR TITLE
Guard wake lock requests when API unsupported

### DIFF
--- a/js/wake_lock.js
+++ b/js/wake_lock.js
@@ -2,6 +2,11 @@
 let wakeLock = null;
 
 export async function requestWakeLock() {
+    if (!('wakeLock' in navigator)) {
+        console.warn('Wake Lock API not supported');
+        return;
+    }
+
     try {
         wakeLock = await navigator.wakeLock.request('screen');
         wakeLock.addEventListener('release', async () => {


### PR DESCRIPTION
## Summary
- prevent wake lock request when API unavailable by checking `navigator.wakeLock`

## Testing
- `node --check js/wake_lock.js && echo 'syntax ok'`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f49b0e9c832997ac88756f7ed0df