### PR TITLE
feat: avoid duplicate wake lock listeners

### DIFF
--- a/js/wake_lock.js
+++ b/js/wake_lock.js
@@ -7,6 +7,10 @@ export async function requestWakeLock() {
         return;
     }
 
+    if (wakeLock) {
+        return;
+    }
+
     try {
         wakeLock = await navigator.wakeLock.request('screen');
         wakeLock.addEventListener('release', async () => {


### PR DESCRIPTION
## Summary
- prevent redundant wakeLock requests by returning early when wakeLock exists

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f583c4608329bc72388edd9c4b85