### PR TITLE
Request wake lock on page load or first interaction

### DIFF
--- a/js/wake_lock.js
+++ b/js/wake_lock.js
@@ -32,5 +32,11 @@ document.addEventListener('visibilitychange', async () => {
 });
 
 if (typeof window !== 'undefined') {
+    window.addEventListener('load', () => {
+        requestWakeLock();
+    });
+    ['click', 'keydown', 'touchstart'].forEach(event => {
+        window.addEventListener(event, () => requestWakeLock(), { once: true });
+    });
     window.requestWakeLock = requestWakeLock;
 }


### PR DESCRIPTION
## Summary
- Ensure wake lock is requested when the page loads.
- Request wake lock on the first user interaction to satisfy user activation requirement.

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f65195c883299132d5448e6a2d43