### PR TITLE
Verify connection on test reset and update UI

### DIFF
--- a/js/speed_test.js
+++ b/js/speed_test.js
@@ -1,9 +1,8 @@
 import { requestWakeLock } from './wake_lock.js';
 
-function resetTestState() {
+async function resetTestState() {
     testInProgress = false;
     pendingRun = false;
-    isConnected = true;
     consecutiveErrors = 0;
 
     if (updateInterval) {
@@ -14,6 +13,21 @@ function resetTestState() {
         clearInterval(dataInterval);
         dataInterval = null;
     }
+
+    isConnected = await checkRealConnection();
+
+    const statusEl = document.getElementById("status");
+    const speedValueEl = document.getElementById("speedValue");
+    const alertIndicatorEl = document.getElementById("alertIndicator");
+
+    if (isConnected) {
+        statusEl.textContent = t('statusReady', 'Натисніть "Почати тест"');
+        alertIndicatorEl.style.display = "none";
+    } else {
+        statusEl.textContent = t('statusNoConnection', 'Відсутнє з\'єднання');
+        alertIndicatorEl.style.display = "block";
+    }
+    speedValueEl.textContent = "0.00";
 }
 
 function updateSpeedPerSecond(bytes, elapsedMs) {
@@ -132,7 +146,7 @@ async function measureDownloadSpeed() {
 
 async function runTest() {
   if (!testActive) {
-    resetTestState();
+    await resetTestState();
     return;
   }
 
@@ -213,7 +227,7 @@ async function runTest() {
     return;
   }
   stopGPS();
-  resetTestState();
+  await resetTestState();
   logTestSummary();
 }
 


### PR DESCRIPTION
## Summary
- Determine actual connectivity in `resetTestState` via `checkRealConnection`
- Update status indicators to reflect connection state after reset
- Await connection reset in `runTest` to maintain accurate state

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/speed_test.js`

------
https://chatgpt.com/codex/tasks/task_e_6894f85278588329b67c6191cee76759