### PR TITLE
Handle test startup failures

### DIFF
--- a/js/speed_test.js
+++ b/js/speed_test.js
@@ -275,8 +275,18 @@ async function toggleTest() {
         testActive = true;
         document.getElementById("startBtn").textContent = t('stopTest', 'Зупинити тест');
 
-        await requestWakeLock();
-        await detectISP();
+        try {
+            await requestWakeLock();
+            await detectISP();
+        } catch (error) {
+            testActive = false;
+            await resetTestState();
+            document.getElementById("startBtn").textContent = t('startTest', 'Почати тест');
+            addLog("Не вдалося запустити тест");
+            showNotification(t('testStartFailed', 'Не вдалося запустити тест'));
+            console.error('toggleTest error:', error);
+            return;
+        }
 
         addLog("Старт тесту");
         showNotification(t('testStarted', 'Тест запущено!'));


### PR DESCRIPTION
## Summary
- Wrap initial asynchronous calls in `toggleTest` with a `try/catch` block
- Reset state and notify user if the test fails to start

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f99e3774832986d78fbdfb24b6b2