### PR TITLE
Prevent parallel runTest loops by disabling start button during init

### DIFF
--- a/js/speed_test.js
+++ b/js/speed_test.js
@@ -273,7 +273,9 @@ async function toggleTest() {
 
     if (!testInProgress) {
         testActive = true;
-        document.getElementById("startBtn").textContent = t('stopTest', 'Зупинити тест');
+        const startBtn = document.getElementById("startBtn");
+        startBtn.disabled = true;
+        startBtn.textContent = t('stopTest', 'Зупинити тест');
 
         try {
             await requestWakeLock();
@@ -281,7 +283,8 @@ async function toggleTest() {
         } catch (error) {
             testActive = false;
             await resetTestState();
-            document.getElementById("startBtn").textContent = t('startTest', 'Почати тест');
+            startBtn.textContent = t('startTest', 'Почати тест');
+            startBtn.disabled = false;
             addLog("Не вдалося запустити тест");
             showNotification(t('testStartFailed', 'Не вдалося запустити тест'));
             console.error('toggleTest error:', error);
@@ -295,6 +298,7 @@ async function toggleTest() {
         isConnected = await checkRealConnection();
         initGPS();
         runTest();
+        startBtn.disabled = false;
     }
 }
 


### PR DESCRIPTION
## Summary
- Disable the start button while initializing a test to avoid rapid re-clicks
- Re-enable the button once initialization completes to allow stopping

## Testing
- `node --check js/speed_test.js`


------
https://chatgpt.com/codex/tasks/task_e_6894fad351288329af5545cdc77a4b40