### PR TITLE
Fix missing ensureColon helper in exported HTML

### DIFF
--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -164,6 +164,10 @@ function getColorBySpeed(speed) {
   return COLOR_GREEN;
 }
 
+function ensureColon(label) {
+  return label.endsWith(':') ? label : label + ':';
+}
+
 /* ------------------ 3. Дані ------------------ */
 const data = ${safeData};
 /* ------------------ 4. Ініціалізація карти ------------------ */


### PR DESCRIPTION
## Summary
- define `ensureColon` helper in generated HTML to prevent `ReferenceError`

## Testing
- `node --check js/download_HTML.js`


------
https://chatgpt.com/codex/tasks/task_e_689503c6e2a483299070f8e439cae292