### PR TITLE
Use rgb syntax for operator colors

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -252,9 +252,9 @@ h1 {
 .status-warning { color: var(--warning-color); }
 
 /* Operator-specific colors */
-.operator-vodafone { color: rgba(230, 0, 0); }
-.operator-kyivstar { color: rgba(0, 160, 228); }
-.operator-lifecell { color: rgba(252, 206, 0); }
+.operator-vodafone { color: rgb(230, 0, 0); }
+.operator-kyivstar { color: rgb(0, 160, 228); }
+.operator-lifecell { color: rgb(252, 206, 0); }
 
 /* Operator name styling */
 #operator {


### PR DESCRIPTION
## Summary
- use `rgb()` color syntax for Vodafone, Kyivstar, and Lifecell operator styles

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python3 - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_6895062f85e883298a9bcf8f1431dd0c