### PR TITLE
Fix mobile info grid spacing

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -609,6 +609,7 @@ h1 {
   /* icon buttons adjust via variables */
 
   .info {
+    display: grid;
     width: 100%;
     grid-template-columns: 1fr;
     row-gap: 10px;


### PR DESCRIPTION
## Summary
- enable grid layout for `.info` on screens ≤768px to ensure spacing works

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895814a9c10832989e91bef8d08beec