### PR TITLE
refactor: rely on CSS specificity for chart canvas

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -141,10 +141,10 @@ h1 {
 }
 
 /* 2) Зробимо сам <canvas> 100% ширини і автоматично розрахуємо висоту */
-.chart-container canvas {
+.chart-section .chart-container > canvas {
   display: block;
-  width: 100% !important;
-  height: 100% !important; /* тепер займає всю висоту контейнера, але контейнер обмежений */
+  width: 100%;
+  height: 100%; /* тепер займає всю висоту контейнера, але контейнер обмежений */
 }
 
 .stats {
@@ -695,8 +695,8 @@ h1 {
     padding: 0; /* інколи зайвий padding “додав” вихід за межі */
   }
 
-  .chart-container canvas {
-    height: auto !important;
+  .chart-section .chart-container > canvas {
+    height: auto;
   }
 
   #map {


### PR DESCRIPTION
## Summary
- remove `!important` from chart canvas sizing
- target chart canvas with more specific selector to maintain responsive sizing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx puppeteer --version` *(fails: 403 Forbidden - GET https://registry.npmjs.org/puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_689582ea52e08329971b0187d0c3fd6a