### PR TITLE
Add PWA manifest id for stable app identifier

### DIFF
--- a/pwa.webmanifest
+++ b/pwa.webmanifest
@@ -1,6 +1,7 @@
 {
     "name": "GO Net Test",
     "short_name": "GO Net Test",
+    "id": "/",
     "description": "A minimal browser-based speed test app.",
     "icons": [
         {


### PR DESCRIPTION
## Summary
- ensure PWA has a stable identifier by adding an `id` field to the manifest

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895951f04bc83299470289f22a8e169