### PR TITLE
Ensure HTML caching completes in Service Worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -85,7 +85,9 @@ self.addEventListener('fetch', event => {
       fetch(event.request)
         .then(response => {
           const clone = response.clone();
-          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          event.waitUntil(
+            caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone))
+          );
           return response;
         })
         .catch(() => caches.match(event.request).then(res => res || caches.match('index.html')))


### PR DESCRIPTION
## Summary
- ensure service worker waits for HTML cache put operations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68959818c49483298aeb75ce1fefcd06