### PR TITLE
Restrict service worker to GET navigation requests

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -75,12 +75,16 @@ self.addEventListener('activate', event => {
 });
 
 self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
   const url = event.request.url;
   if (url.includes('speed.cloudflare.com') || url.includes('generate_204')) {
     // Let the browser handle these requests normally without caching
     return;
   }
-  if (event.request.headers.get('Accept')?.includes('text/html')) {
+  if (event.request.mode === 'navigate') {
     event.respondWith(
       fetch(event.request)
         .then(response => {


### PR DESCRIPTION
## Summary
- handle only GET requests in the service worker's fetch handler
- rely on `event.request.mode === 'navigate'` for navigation detection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689599b8a0188329bf4bd164547c2e79