### PR TITLE
Fix international roads label text

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
       <div class="setting-group">
         <div class="checkbox-group">
           <input type="checkbox" id="showInternationalRoads" />
-          <label class="setting-label" for="showInternationalRoads" data-i18n="showInternationalRoadsLabel">ВМіжнародні дороги</label>
+          <label class="setting-label" for="showInternationalRoads" data-i18n="showInternationalRoadsLabel">Міжнародні дороги</label>
         </div>
       </div>
       <div class="setting-group">


### PR DESCRIPTION
## Summary
- Correct typo in international roads setting label

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68959deacc2c832985d9a92e025eb4a0