### PR TITLE
Defer logging scripts and initialize icons after load

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,8 +37,8 @@
   <script defer src="js/config.js"></script>
   <script defer src="js/lang.js"></script>
   <script defer src="js/storage.js"></script>
-  <script src="js/log.js"></script>
-  <script src="js/detect_ISP.js"></script>
+  <script defer src="js/log.js"></script>
+  <script defer src="js/detect_ISP.js"></script>
   <script defer src="js/format_seconds.js"></script>
   <script defer src="js/format_downloaded.js"></script>
   <script defer src="js/audio_notification.js"></script>
@@ -81,7 +81,7 @@
 
   <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 
-  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+  <script defer src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
 </head>
 
 <body data-theme="dark">
@@ -113,7 +113,11 @@
     </div>
 
     <script>
-      lucide.createIcons({ strokeWidth: 1.5, class: 'h-6 w-6' });
+      document.addEventListener('DOMContentLoaded', () => {
+        if (window.lucide) {
+          lucide.createIcons({ strokeWidth: 1.5, class: 'h-6 w-6' });
+        }
+      });
     </script>
 
     <!-- Налаштування -->

--- a/js/add_event_listener.js
+++ b/js/add_event_listener.js
@@ -22,10 +22,6 @@ window.addEventListener("DOMContentLoaded", async () => {
     updateDataDisplay();
     updateDatabaseInfo();
 
-    if (window.lucide) {
-        lucide.createIcons({ strokeWidth: 1.5, class: 'h-6 w-6' });
-    }
-
 });
 
 // Обробка зміни орієнтації для мобільних


### PR DESCRIPTION
## Summary
- defer log.js, detect_ISP.js, and lucide library to allow parallel loading
- initialize lucide icons once DOM is ready
- remove redundant lucide initialization in add_event_listener

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895a11d82208329b67501251f87f33b