### PR TITLE
refactor: share map helper functions

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
   <script defer src="js/log_test_summary.js"></script>
   <script defer src="js/chart.js"></script>
   <script defer src="js/update_stats.js"></script>
-  <script defer src="js/map.js"></script>
+  <script type="module" src="js/map.js"></script>
     <script defer src="js/map_zoom.js"></script>
     <script defer src="js/find_admin_unit.js"></script>
     <script defer src="js/hromada_change_announcer.js"></script>
@@ -62,7 +62,7 @@
   <script defer src="js/replace_spaces_with_underscore.js"></script>
   <script defer src="js/download_CSV.js"></script>
   <script defer src="js/download_KML.js"></script>
-  <script defer src="js/download_HTML.js"></script>
+  <script type="module" src="js/download_HTML.js"></script>
   <script defer src="js/download_chart.js"></script>
   <script defer src="js/clear_data.js"></script>
   <script defer src="js/update_UI.js"></script>

--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -1,3 +1,5 @@
+import { getColorBySpeed, ensureColon, addMapMarker } from './map_utils.js';
+
 function downloadHTML() {
     if (typeof speedData === 'undefined' || !Array.isArray(speedData)) {
         console.error('speedData is undefined');
@@ -47,6 +49,9 @@ function downloadHTML() {
         console.error('window.getMarkerPopupContent is not a function');
         return;
     }
+    const getColorBySpeedSrc = getColorBySpeed.toString();
+    const ensureColonSrc = ensureColon.toString();
+    const addMapMarkerSrc = addMapMarker.toString();
     let getMarkerPopupContentSrc = window.getMarkerPopupContent.toString();
 
     if (!getMarkerPopupContentSrc.includes("distanceColumn")) {
@@ -157,21 +162,16 @@ const COLOR_RED    = 'red';
 const COLOR_YELLOW = 'yellow';
 const COLOR_GREEN  = 'green';
 
-/* ------------------ 2. Функція кольору за швидкістю ------------------ */
-function getColorBySpeed(speed) {
-  if (speed <= 0) return COLOR_RED;
-  if (speed <= 2) return COLOR_YELLOW;
-  return COLOR_GREEN;
-}
+/* ------------------ 2. Допоміжні функції ------------------ */
+${getColorBySpeedSrc}
 
-function ensureColon(label) {
-  return label.endsWith(':') ? label : label + ':';
-}
+${ensureColonSrc}
 
 /* ------------------ 3. Дані ------------------ */
 const data = ${safeData};
 /* ------------------ 4. Ініціалізація карти ------------------ */
 const map = L.map('map');
+const mapMarkers = [];
 const osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   maxZoom: 19,
   attribution: '© OpenStreetMap contributors'
@@ -209,33 +209,10 @@ greenCluster.addTo(map);
 ${getMarkerPopupContentSrc}
 
 /* ------------------ 9. Додавання маркерів ------------------ */
-function addMapMarker(point) {
-  if (point.latitude == null || point.longitude == null) return;
-  const color = getColorBySpeed(point.speed);
-
-  const marker = L.circleMarker([point.latitude, point.longitude], {
-    radius: 18,
-    color: color,
-    weight: 2,
-    fillColor: color,
-    fillOpacity: 0.85
-  });
-
-  marker.bindPopup(getMarkerPopupContent(point));
-  marker.options.speedValue = point.speed;
-  marker.options.speedColor = color;
-
-  if (color === COLOR_RED) {
-    redCluster.addLayer(marker);
-  } else if (color === COLOR_YELLOW) {
-    yellowCluster.addLayer(marker);
-  } else {
-    greenCluster.addLayer(marker);
-  }
-}
+${addMapMarkerSrc}
 
 /* ------------------ 10. Завантаження всіх точок ------------------ */
-data.forEach(pt => addMapMarker(pt));
+data.forEach(pt => addMapMarker(pt, false));
 
 /* ------------------ 11. Авто-фокус на всіх маркерах ------------------ */
 const coords = data
@@ -271,3 +248,5 @@ L.control.layers(null, overlays, { collapsed: true }).addTo(map);
 
     showNotification(t('htmlDownloaded', 'HTML файл завантажено!'));
 }
+
+window.downloadHTML = downloadHTML;

--- a/js/map.js
+++ b/js/map.js
@@ -1,12 +1,4 @@
-function getColorBySpeed(speed) {
-    if (speed <= 0) return 'red';
-    if (speed <= 2) return 'yellow';
-    return 'green';
-}
-
-function ensureColon(label) {
-    return label.endsWith(':') ? label : label + ':';
-}
+import { getColorBySpeed, ensureColon, addMapMarker } from './map_utils.js';
 
 function initMap() {
     if (mapInitialized) return;
@@ -133,51 +125,6 @@ function getMarkerPopupContent(point) {
     return rows
         .map(r => `<div><strong>${r[0]}</strong> ${r[1]}</div>`)
         .join('');
-}
-
-function addMapMarker(point, centerOnAdd = true) {
-    if (!map || point.latitude == null || point.longitude == null) return;
-    const color = getColorBySpeed(point.speed);
-    const marker = L.circleMarker([point.latitude, point.longitude], {
-        radius: 6,
-        color,
-        fillColor: color,
-        fillOpacity: 0.8,
-    });
-
-    if (color === 'red' && redCluster) {
-        redCluster.addLayer(marker);
-    } else if (color === 'yellow' && yellowCluster) {
-        yellowCluster.addLayer(marker);
-    } else if (greenCluster) {
-        greenCluster.addLayer(marker);
-    } else {
-        marker.addTo(map);
-    }
-    if (typeof marker.bindPopup === 'function') {
-        marker.bindPopup(getMarkerPopupContent(point), { autoPan: false });
-    }
-    mapMarkers.push(marker);
-    if (centerOnAdd) {
-        let openPopup = null;
-        if (typeof map.getPopup === 'function') {
-            openPopup = map.getPopup();
-        } else if (typeof map.eachLayer === 'function') {
-            map.eachLayer(layer => {
-                if (
-                    !openPopup &&
-                    layer instanceof L.Popup &&
-                    typeof layer.isOpen === 'function' &&
-                    layer.isOpen()
-                ) {
-                    openPopup = layer;
-                }
-            });
-        }
-        if (!(openPopup && map.hasLayer(openPopup))) {
-            map.setView([point.latitude, point.longitude], map.getZoom());
-        }
-    }
 }
 
 function getRoadPopupContent(props) {

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -1,0 +1,54 @@
+export function getColorBySpeed(speed) {
+    if (speed <= 0) return 'red';
+    if (speed <= 2) return 'yellow';
+    return 'green';
+}
+
+export function ensureColon(label) {
+    return label.endsWith(':') ? label : label + ':';
+}
+
+export function addMapMarker(point, centerOnAdd = true) {
+    if (!map || point.latitude == null || point.longitude == null) return;
+    const color = getColorBySpeed(point.speed);
+    const marker = L.circleMarker([point.latitude, point.longitude], {
+        radius: 6,
+        color,
+        fillColor: color,
+        fillOpacity: 0.8,
+    });
+
+    if (color === 'red' && redCluster) {
+        redCluster.addLayer(marker);
+    } else if (color === 'yellow' && yellowCluster) {
+        yellowCluster.addLayer(marker);
+    } else if (greenCluster) {
+        greenCluster.addLayer(marker);
+    } else {
+        marker.addTo(map);
+    }
+    if (typeof window.getMarkerPopupContent === 'function' && typeof marker.bindPopup === 'function') {
+        marker.bindPopup(window.getMarkerPopupContent(point), { autoPan: false });
+    }
+    mapMarkers.push(marker);
+    if (centerOnAdd) {
+        let openPopup = null;
+        if (typeof map.getPopup === 'function') {
+            openPopup = map.getPopup();
+        } else if (typeof map.eachLayer === 'function') {
+            map.eachLayer(layer => {
+                if (
+                    !openPopup &&
+                    layer instanceof L.Popup &&
+                    typeof layer.isOpen === 'function' &&
+                    layer.isOpen()
+                ) {
+                    openPopup = layer;
+                }
+            });
+        }
+        if (!(openPopup && map.hasLayer(openPopup))) {
+            map.setView([point.latitude, point.longitude], map.getZoom());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- centralize getColorBySpeed, ensureColon and addMapMarker helpers in `map_utils.js`
- import shared helpers in `map.js` and `download_HTML.js`
- load map scripts as ES modules for shared imports

## Testing
- `node --check --experimental-default-type=module js/map_utils.js js/map.js js/download_HTML.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895a72dc5288329b1894fa6cc85071b