### PR TITLE
Fix undefined map observer function

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -279,3 +279,5 @@ window.getMarkerPopupContent = getMarkerPopupContent;
 window.addMapMarker = addMapMarker;
 window.updateHromadyLayer = updateHromadyLayer;
 window.updateRoadLayers = updateRoadLayers;
+window.setupMapObserver = setupMapObserver;
+window.initMapIfNeeded = initMapIfNeeded;


### PR DESCRIPTION
## Summary
- Export `setupMapObserver` and `initMapIfNeeded` to the global scope
- Prevent `setupMapObserver` reference error during startup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895aa543b4c83298026197409ac5cc0