### PR TITLE
refactor: centralize blob downloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
   <script defer src="js/update_road_stats.js"></script>
   <script defer src="js/update_admin_stats.js"></script>
   <script defer src="js/replace_spaces_with_underscore.js"></script>
+  <script defer src="js/file_download.js"></script>
   <script defer src="js/download_CSV.js"></script>
   <script defer src="js/download_KML.js"></script>
   <script type="module" src="js/download_HTML.js"></script>

--- a/js/download_CSV.js
+++ b/js/download_CSV.js
@@ -82,15 +82,10 @@ function downloadCSV() {
                 .join("\n");
 
         const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-        const link = document.createElement("a");
-        link.href = URL.createObjectURL(blob);
-        link.download = `${replaceSpacesWithUnderscore(operator)}_${dateStr}_${timeStr}.csv`;
-        link.style.display = "none";
-        document.body.appendChild(link);
-        link.click();
-        URL.revokeObjectURL(link.href);
-        document.body.removeChild(link);
-
+        saveBlob(
+            blob,
+            `${replaceSpacesWithUnderscore(operator)}_${dateStr}_${timeStr}.csv`
+        );
         showNotification(t('dataDownloaded', 'Дані завантажено!'));
     } finally {
         if (downloadBtn) downloadBtn.disabled = false;

--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -238,14 +238,7 @@ L.control.layers(null, overlays, { collapsed: true }).addTo(map);
 </html>`;
 
     const blob = new Blob([htmlContent], { type: 'text/html' });
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = `${baseFileName}.html`;
-    document.body.appendChild(link);
-    link.click();
-    URL.revokeObjectURL(link.href);
-    document.body.removeChild(link);
-
+    saveBlob(blob, `${baseFileName}.html`);
     showNotification(t('htmlDownloaded', 'HTML файл завантажено!'));
 }
 

--- a/js/download_KML.js
+++ b/js/download_KML.js
@@ -121,13 +121,6 @@ function downloadKML() {
     const blob = new Blob([kmlContent], {
         type: 'application/vnd.google-earth.kml+xml',
     });
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = `${baseFileName}.kml`;
-    document.body.appendChild(link);
-    link.click();
-    URL.revokeObjectURL(link.href);
-    document.body.removeChild(link);
-
+    saveBlob(blob, `${baseFileName}.kml`);
     showNotification(t('kmlDownloaded', 'KML файл завантажено!'));
 }

--- a/js/download_chart.js
+++ b/js/download_chart.js
@@ -1,16 +1,14 @@
-function downloadChart() {
+async function downloadChart() {
     if (!speedChart) return;
 
     try {
-        const link = document.createElement("a");
-        link.download = `speed_chart_${new Date()
-            .toISOString()
-            .slice(0, 10)}.png`;
-        link.href = speedChart.toBase64Image();
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-
+        const dataUrl = speedChart.toBase64Image();
+        const response = await fetch(dataUrl);
+        const blob = await response.blob();
+        saveBlob(
+            blob,
+            `speed_chart_${new Date().toISOString().slice(0, 10)}.png`
+        );
         showNotification(t('chartExported', 'Графік експортовано!'));
     } catch (e) {
         showNotification(

--- a/js/file_download.js
+++ b/js/file_download.js
@@ -1,0 +1,10 @@
+function saveBlob(blob, fileName) {
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = fileName;
+    link.style.display = 'none';
+    document.body.appendChild(link);
+    link.click();
+    URL.revokeObjectURL(link.href);
+    document.body.removeChild(link);
+}


### PR DESCRIPTION
## Summary
- add saveBlob helper for saving Blobs
- reuse saveBlob in CSV/KML/HTML/chart downloads
- load saveBlob script globally

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895a9af17188329ae06248819654d5c