### PR TITLE
feat: centralize timestamp formatting for downloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
   <script defer src="js/update_road_stats.js"></script>
   <script defer src="js/update_admin_stats.js"></script>
   <script defer src="js/replace_spaces_with_underscore.js"></script>
+  <script defer src="js/time_utils.js"></script>
   <script defer src="js/file_download.js"></script>
   <script defer src="js/download_CSV.js"></script>
   <script defer src="js/download_KML.js"></script>

--- a/js/download_CSV.js
+++ b/js/download_CSV.js
@@ -8,9 +8,6 @@ function downloadCSV() {
     if (downloadBtn) downloadBtn.disabled = true;
 
     try {
-        let dateStr = '';
-        let timeStr = '';
-
         // ✨  Додали три нові заголовки після "Час" та колонку "Відстань" після "GPS Швидкість"
         const headers =
             "Часова мітка (мс);" +
@@ -37,23 +34,12 @@ function downloadCSV() {
             headers +
             speedData
                 .map((record) => {
-                    // Перевірка, якщо зберігали Date – використовуємо напряму, інакше створюємо об’єкт Date
                     const ts =
                         record.fullTimestamp instanceof Date
                             ? record.fullTimestamp
                             : new Date(record.fullTimestamp);
 
-                    // Формати дати й часу з 2-цифровими компонентами
-                    dateStr = ts.toLocaleDateString("uk-UA", {
-                        day: "2-digit",
-                        month: "2-digit",
-                        year: "numeric",
-                    });
-                    timeStr = ts.toLocaleTimeString("uk-UA", {
-                        hour: "2-digit",
-                        minute: "2-digit",
-                        second: "2-digit",
-                    });
+                    const { dateStr, timeStr } = formatTimestamp(ts);
 
                     return (
                         `${ts.getTime()};` +                       // Часова мітка (мс)
@@ -77,6 +63,17 @@ function downloadCSV() {
                     );
                 })
                 .join("\n");
+
+        const lastRecord = speedData[speedData.length - 1];
+        let dateStr = '';
+        let timeStr = '';
+        if (lastRecord && lastRecord.fullTimestamp) {
+            ({ dateStr, timeStr } = formatTimestamp(lastRecord.fullTimestamp, {
+                forFilename: true,
+                dateSeparator: '.',
+                timeSeparator: '-',
+            }));
+        }
 
         const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
         saveBlob(

--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -20,22 +20,11 @@ function downloadHTML() {
     let timeStr = '';
     const lastRecord = speedData[speedData.length - 1];
     if (lastRecord && lastRecord.fullTimestamp) {
-        const ts =
-            lastRecord.fullTimestamp instanceof Date
-                ? lastRecord.fullTimestamp
-                : new Date(lastRecord.fullTimestamp);
-        dateStr = ts.toLocaleDateString('uk-UA', {
-            day: '2-digit',
-            month: '2-digit',
-            year: 'numeric',
-        });
-        timeStr = ts
-            .toLocaleTimeString('uk-UA', {
-                hour: '2-digit',
-                minute: '2-digit',
-                second: '2-digit',
-            })
-            .replace(/:/g, '-');
+        ({ dateStr, timeStr } = formatTimestamp(lastRecord.fullTimestamp, {
+            forFilename: true,
+            dateSeparator: '.',
+            timeSeparator: '-',
+        }));
     }
 
     const baseFileName = `${replaceSpacesWithUnderscore(operator)}_${dateStr}_${timeStr}`;

--- a/js/download_KML.js
+++ b/js/download_KML.js
@@ -7,24 +7,9 @@ function downloadKML() {
     // Use timestamp of the last record to build file and layer names
     const lastRecord = speedData[speedData.length - 1];
     if (lastRecord && lastRecord.fullTimestamp) {
-        const ts =
-            lastRecord.fullTimestamp instanceof Date
-                ? lastRecord.fullTimestamp
-                : new Date(lastRecord.fullTimestamp);
-        dateStr = ts
-            .toLocaleDateString('uk-UA', {
-                day: '2-digit',
-                month: '2-digit',
-                year: 'numeric',
-            })
-            .replace(/[^\d]+/g, '-');
-        timeStr = ts
-            .toLocaleTimeString('uk-UA', {
-                hour: '2-digit',
-                minute: '2-digit',
-                second: '2-digit',
-            })
-            .replace(/[^\d]+/g, '-');
+        ({ dateStr, timeStr } = formatTimestamp(lastRecord.fullTimestamp, {
+            forFilename: true,
+        }));
     }
 
     const baseFileName = `${replaceSpacesWithUnderscore(operator)}_${dateStr}_${timeStr}`;
@@ -58,16 +43,7 @@ function downloadKML() {
             record.fullTimestamp instanceof Date
                 ? record.fullTimestamp
                 : new Date(record.fullTimestamp);
-        const dateStr = ts.toLocaleDateString('uk-UA', {
-            day: '2-digit',
-            month: '2-digit',
-            year: 'numeric',
-        });
-        const timeStr = ts.toLocaleTimeString('uk-UA', {
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit',
-        });
+        const { dateStr, timeStr } = formatTimestamp(ts);
 
         const description =
             `Часова мітка (мс): ${ts.getTime()}<br>` +

--- a/js/time_utils.js
+++ b/js/time_utils.js
@@ -1,0 +1,24 @@
+function formatTimestamp(ts, options = {}) {
+    const {
+        locale = 'uk-UA',
+        forFilename = false,
+        dateSeparator = forFilename ? '-' : '.',
+        timeSeparator = forFilename ? '-' : ':',
+    } = options;
+
+    const dateOptions = { day: '2-digit', month: '2-digit', year: 'numeric' };
+    const timeOptions = { hour: '2-digit', minute: '2-digit', second: '2-digit' };
+
+    const dateObj = ts instanceof Date ? ts : new Date(ts);
+
+    let dateStr = dateObj.toLocaleDateString(locale, dateOptions);
+    let timeStr = dateObj.toLocaleTimeString(locale, timeOptions);
+
+    if (forFilename) {
+        dateStr = dateStr.replace(/[^0-9]+/g, dateSeparator);
+        timeStr = timeStr.replace(/[^0-9]+/g, timeSeparator);
+    }
+
+    return { dateStr, timeStr };
+}
+


### PR DESCRIPTION
## Summary
- add `formatTimestamp` helper with optional filename-friendly formatting
- use `formatTimestamp` across CSV, KML, and HTML downloads
- include new utility script in page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ad50b54c8329bfa405a8cdbff81f