### PR TITLE
refactor stats accumulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
   <script defer src="js/update_data_display.js"></script>
   <script defer src="js/update_database_info.js"></script>
   <script defer src="js/update_speed_distribution.js"></script>
+  <script defer src="js/stats_utils.js"></script>
   <script defer src="js/update_road_stats.js"></script>
   <script defer src="js/update_admin_stats.js"></script>
   <script defer src="js/replace_spaces_with_underscore.js"></script>

--- a/js/stats_utils.js
+++ b/js/stats_utils.js
@@ -1,0 +1,15 @@
+function accumulateSpeedStats(target, speed, distance) {
+    const dist = distance || 0;
+    target.total++;
+    if (speed === 0) {
+        target.zero++;
+        target.distZero += dist;
+    } else if (speed > 0 && speed <= 2) {
+        target.upto2++;
+        target.distUpto2 += dist;
+    } else {
+        target.above2++;
+        target.distAbove2 += dist;
+    }
+}
+

--- a/js/update_admin_stats.js
+++ b/js/update_admin_stats.js
@@ -4,21 +4,6 @@ function escapeHtml(str) {
     return div.innerHTML;
 }
 
-function accumulateAdminStats(target, speed, distance) {
-    const dist = distance || 0;
-    target.total++;
-    if (speed === 0) {
-        target.zero++;
-        target.distZero += dist;
-    } else if (speed > 0 && speed <= 2) {
-        target.upto2++;
-        target.distUpto2 += dist;
-    } else {
-        target.above2++;
-        target.distAbove2 += dist;
-    }
-}
-
 function updateAdminStats() {
     const container = document.getElementById('adminStatsContent');
     if (!container) return;
@@ -35,7 +20,7 @@ function updateAdminStats() {
         }
         const reg = stats[rec.region];
         const dist = rec.distance || 0;
-        accumulateAdminStats(reg, rec.speed, dist);
+        accumulateSpeedStats(reg, rec.speed, dist);
 
         if (rec.rayon) {
             if (!reg.raions[rec.rayon]) {
@@ -46,7 +31,7 @@ function updateAdminStats() {
                 };
             }
             const ray = reg.raions[rec.rayon];
-            accumulateAdminStats(ray, rec.speed, dist);
+            accumulateSpeedStats(ray, rec.speed, dist);
 
             if (rec.hromada) {
                 if (!ray.hromady[rec.hromada]) {
@@ -56,7 +41,7 @@ function updateAdminStats() {
                     };
                 }
                 const h = ray.hromady[rec.hromada];
-                accumulateAdminStats(h, rec.speed, dist);
+                accumulateSpeedStats(h, rec.speed, dist);
             }
         }
     }

--- a/js/update_road_stats.js
+++ b/js/update_road_stats.js
@@ -39,18 +39,8 @@ function updateRoadStats() {
             };
         }
         const s = stats[ref];
-        s.total++;
         const dist = rec.distance || 0;
-        if (rec.speed === 0) {
-            s.zero++;
-            s.distZero += dist;
-        } else if (rec.speed > 0 && rec.speed <= 2) {
-            s.upto2++;
-            s.distUpto2 += dist;
-        } else {
-            s.above2++;
-            s.distAbove2 += dist;
-        }
+        accumulateSpeedStats(s, rec.speed, dist);
     }
 
     const keys = Object.keys(stats).sort();


### PR DESCRIPTION
## Summary
- factor out generic `accumulateSpeedStats` utility
- use shared accumulator in admin and road stats modules
- wire up new helper in HTML

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895b7a448648329af5e1e1c2ed34b94