### PR TITLE
refactor: unify change announcers

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
   <script type="module" src="js/map.js"></script>
     <script defer src="js/map_zoom.js"></script>
     <script defer src="js/find_admin_unit.js"></script>
+    <script defer src="js/change_announcer.js"></script>
     <script defer src="js/hromada_change_announcer.js"></script>
     <script defer src="js/road_change_announcer.js"></script>
     <script defer src="js/update_GPS_info.js"></script>

--- a/js/change_announcer.js
+++ b/js/change_announcer.js
@@ -1,0 +1,35 @@
+// js/change_announcer.js
+
+function createChangeAnnouncer(settingsKey, getMessage, keyList) {
+    let lastState = {};
+    keyList.forEach(key => {
+        lastState[key] = null;
+    });
+
+    return function(info) {
+        if (!info) {
+            lastState = {};
+            keyList.forEach(key => {
+                lastState[key] = null;
+            });
+            return;
+        }
+
+        const currentState = {};
+        keyList.forEach(key => {
+            currentState[key] = info[key] ?? null;
+        });
+
+        const hasChanged = keyList.some(key => lastState[key] !== currentState[key]);
+
+        if (settings[settingsKey] && hasChanged) {
+            const message = getMessage(currentState, info);
+            if (message) {
+                speak(message.trim());
+            }
+        }
+
+        lastState = currentState;
+    };
+}
+

--- a/js/hromada_change_announcer.js
+++ b/js/hromada_change_announcer.js
@@ -1,34 +1,13 @@
 // js/hromada_change_announcer.js
-let lastAdminUnit = { region: null, rayon: null, hromada: null };
 
-function announceAdminChange(info) {
-    if (!info) {
-        lastAdminUnit = { region: null, rayon: null, hromada: null };
-        return;
-    }
+const announceAdminChange = createChangeAnnouncer(
+    'voiceHromadaChange',
+    state => {
+        const region = state.region ?? '';
+        const rayon = state.rayon ?? '';
+        const hromada = state.hromada ?? '';
+        return `Вас вітає ${hromada} ${rayon} район ${region} область`;
+    },
+    ['region', 'rayon', 'hromada']
+);
 
-    if (!info.region || !info.rayon || !info.hromada) {
-        console.warn('announceAdminChange: incomplete info', info);
-    }
-
-    if (settings.voiceHromadaChange) {
-        if (
-            !lastAdminUnit.hromada ||
-            lastAdminUnit.hromada !== info.hromada ||
-            lastAdminUnit.rayon !== info.rayon ||
-            lastAdminUnit.region !== info.region
-        ) {
-            const region = info.region ?? '';
-            const rayon = info.rayon ?? '';
-            const hromada = info.hromada ?? '';
-            const message = `Вас вітає ${hromada} ${rayon} район ${region} область`;
-            speak(message.trim());
-        }
-    }
-
-    lastAdminUnit = {
-        region: info.region,
-        rayon: info.rayon,
-        hromada: info.hromada
-    };
-}

--- a/js/road_change_announcer.js
+++ b/js/road_change_announcer.js
@@ -1,34 +1,32 @@
 // js/road_change_announcer.js
-let lastRoad = { ref: null, name: null, network: null };
 
-function announceRoadChange(road) {
-    if (!road) {
-        lastRoad = { ref: null, name: null, network: null };
-        return;
-    }
-
-    const currentRef = road.ref || null;
-    const currentName = road.official_name || road['name:uk'] || road.name || null;
-    const currentNetwork = road.network || null;
-
-    if (settings.voiceRoadChange) {
-        const isInitial =
-            lastRoad.ref === null &&
-            lastRoad.name === null &&
-            lastRoad.network === null;
-        const hasChanged =
-            lastRoad.ref !== currentRef ||
-            lastRoad.name !== currentName ||
-            lastRoad.network !== currentNetwork;
-
-        if (isInitial || hasChanged) {
-            const refPart = currentRef ? `${currentRef}` : '';
-            const namePart = currentName ? `${currentName}` : '';
-            const networkPart = currentNetwork ? `${currentNetwork}` : '';
+const announceRoadChange = (function() {
+    const announcer = createChangeAnnouncer(
+        'voiceRoadChange',
+        state => {
+            const refPart = state.ref ? `${state.ref}` : '';
+            const namePart = state.name ? `${state.name}` : '';
+            const networkPart = state.network ? `${state.network}` : '';
             const parts = [refPart, namePart, networkPart].filter(part => part);
-            speak(['Ви виїхали на дорогу', ...parts].join(' '));
-        }
-    }
+            if (parts.length === 0) {
+                return null;
+            }
+            return ['Ви виїхали на дорогу', ...parts].join(' ');
+        },
+        ['ref', 'name', 'network']
+    );
 
-    lastRoad = { ref: currentRef, name: currentName, network: currentNetwork };
-}
+    return function(road) {
+        if (!road) {
+            announcer(null);
+            return;
+        }
+        const info = {
+            ref: road.ref || null,
+            name: road.official_name || road['name:uk'] || road.name || null,
+            network: road.network || null
+        };
+        announcer(info);
+    };
+})();
+


### PR DESCRIPTION
## Summary
- add generic `createChangeAnnouncer` to handle change notifications with shared settings logic
- refactor admin and road announcers to use new helper
- include `change_announcer.js` in page scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895b8675bc08329abd8f28e1ef97590