### PR TITLE
refactor: centralize file name generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
   <script defer src="js/replace_spaces_with_underscore.js"></script>
   <script defer src="js/time_utils.js"></script>
   <script defer src="js/file_download.js"></script>
+  <script defer src="js/download_utils.js"></script>
   <script defer src="js/download_CSV.js"></script>
   <script defer src="js/download_KML.js"></script>
   <script type="module" src="js/download_HTML.js"></script>

--- a/js/download_CSV.js
+++ b/js/download_CSV.js
@@ -64,22 +64,10 @@ function downloadCSV() {
                 })
                 .join("\n");
 
-        const lastRecord = speedData[speedData.length - 1];
-        let dateStr = '';
-        let timeStr = '';
-        if (lastRecord && lastRecord.fullTimestamp) {
-            ({ dateStr, timeStr } = formatTimestamp(lastRecord.fullTimestamp, {
-                forFilename: true,
-                dateSeparator: '.',
-                timeSeparator: '-',
-            }));
-        }
+        const baseFileName = buildBaseFileName(speedData, operator);
 
         const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-        saveBlob(
-            blob,
-            `${replaceSpacesWithUnderscore(operator)}_${dateStr}_${timeStr}.csv`
-        );
+        saveBlob(blob, `${baseFileName}.csv`);
         showNotification(t('dataDownloaded', 'Дані завантажено!'));
     } finally {
         if (downloadBtn) downloadBtn.disabled = false;

--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -16,18 +16,7 @@ function downloadHTML() {
 
     if (!assertSpeedData('noData', 'Немає даних для завантаження')) return;
 
-    let dateStr = '';
-    let timeStr = '';
-    const lastRecord = speedData[speedData.length - 1];
-    if (lastRecord && lastRecord.fullTimestamp) {
-        ({ dateStr, timeStr } = formatTimestamp(lastRecord.fullTimestamp, {
-            forFilename: true,
-            dateSeparator: '.',
-            timeSeparator: '-',
-        }));
-    }
-
-    const baseFileName = `${replaceSpacesWithUnderscore(operator)}_${dateStr}_${timeStr}`;
+    const baseFileName = buildBaseFileName(speedData, operator);
 
     const safeData = JSON.stringify(speedData).replace(/<\/script>/g, '<\\/script>');
 

--- a/js/download_KML.js
+++ b/js/download_KML.js
@@ -1,18 +1,7 @@
 function downloadKML() {
     if (!assertSpeedData('noData', 'Немає даних для завантаження')) return;
 
-    let dateStr = '';
-    let timeStr = '';
-
-    // Use timestamp of the last record to build file and layer names
-    const lastRecord = speedData[speedData.length - 1];
-    if (lastRecord && lastRecord.fullTimestamp) {
-        ({ dateStr, timeStr } = formatTimestamp(lastRecord.fullTimestamp, {
-            forFilename: true,
-        }));
-    }
-
-    const baseFileName = `${replaceSpacesWithUnderscore(operator)}_${dateStr}_${timeStr}`;
+    const baseFileName = buildBaseFileName(speedData, operator);
 
     let kmlContent =
         '<?xml version="1.0" encoding="UTF-8"?>\n' +

--- a/js/download_utils.js
+++ b/js/download_utils.js
@@ -1,0 +1,15 @@
+function buildBaseFileName(speedData, operator) {
+    const lastRecord = Array.isArray(speedData)
+        ? speedData[speedData.length - 1]
+        : null;
+    let dateStr = '';
+    let timeStr = '';
+    if (lastRecord && lastRecord.fullTimestamp) {
+        ({ dateStr, timeStr } = formatTimestamp(lastRecord.fullTimestamp, {
+            forFilename: true,
+            dateSeparator: '.',
+            timeSeparator: '-',
+        }));
+    }
+    return `${replaceSpacesWithUnderscore(operator)}_${dateStr}_${timeStr}`;
+}


### PR DESCRIPTION
## Summary
- add `buildBaseFileName` helper for download filenames
- use `buildBaseFileName` in CSV, HTML and KML exports
- load new download utility module

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895baa72450832983a587685d5f1d0a