### PR TITLE
Refactor stats toggling with shared helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
   <script defer src="js/update_database_info.js"></script>
   <script defer src="js/update_speed_distribution.js"></script>
   <script defer src="js/stats_utils.js"></script>
+  <script defer src="js/toggle_section.js"></script>
   <script defer src="js/update_road_stats.js"></script>
   <script defer src="js/update_admin_stats.js"></script>
   <script defer src="js/replace_spaces_with_underscore.js"></script>

--- a/js/toggle_section.js
+++ b/js/toggle_section.js
@@ -1,0 +1,18 @@
+function setupToggle(container, selector) {
+    if (!container) return;
+    container.querySelectorAll(selector).forEach(el => {
+        const target = el.dataset.target;
+        const icon = el.querySelector('i');
+        el.addEventListener('click', () => {
+            const cont = document.getElementById(target);
+            if (!cont) return;
+            cont.classList.toggle('hidden');
+            if (icon) {
+                icon.setAttribute('data-lucide', cont.classList.contains('hidden') ? 'plus' : 'minus');
+                if (window.lucide) {
+                    lucide.createIcons({ strokeWidth: 1.2, class: 'h-4 w-4' });
+                }
+            }
+        });
+    });
+}

--- a/js/update_admin_stats.js
+++ b/js/update_admin_stats.js
@@ -109,17 +109,5 @@ function updateAdminStats() {
     container.innerHTML = rows.join('');
     if (window.lucide) lucide.createIcons({ strokeWidth: 1.2, class: 'h-4 w-4' });
 
-    container.querySelectorAll('.admin-toggle').forEach(el => {
-        const target = el.dataset.target;
-        const icon = el.querySelector('i');
-        el.addEventListener('click', () => {
-            const cont = document.getElementById(target);
-            if (!cont) return;
-            cont.classList.toggle('hidden');
-            if (icon) {
-                icon.setAttribute('data-lucide', cont.classList.contains('hidden') ? 'plus' : 'minus');
-                if (window.lucide) lucide.createIcons({ strokeWidth: 1.2, class: 'h-4 w-4' });
-            }
-        });
-    });
+    setupToggle(container, '.admin-toggle');
 }

--- a/js/update_road_stats.js
+++ b/js/update_road_stats.js
@@ -85,17 +85,5 @@ function updateRoadStats() {
     container.innerHTML = rows.join('');
     if (window.lucide) lucide.createIcons({ strokeWidth: 1.2, class: 'h-4 w-4' });
 
-    container.querySelectorAll('.road-toggle').forEach(el => {
-        const target = el.dataset.target;
-        const icon = el.querySelector('i');
-        el.addEventListener('click', () => {
-            const cont = document.getElementById(target);
-            if (!cont) return;
-            cont.classList.toggle('hidden');
-            if (icon) {
-                icon.setAttribute('data-lucide', cont.classList.contains('hidden') ? 'plus' : 'minus');
-                if (window.lucide) lucide.createIcons({ strokeWidth: 1.2, class: 'h-4 w-4' });
-            }
-        });
-    });
+    setupToggle(container, '.road-toggle');
 }


### PR DESCRIPTION
## Summary
- add `setupToggle` to centralize handling of toggling sections and icons
- replace manual toggle loops in admin and road stats modules
- include new helper script in `index.html`

## Testing
- `node -e "require('./js/toggle_section.js'); require('./js/update_admin_stats.js'); require('./js/update_road_stats.js'); console.log('modules loaded')"`
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6895bc1aa3048329b48ab6780d67f77f