### PR TITLE
refactor: centralize speed data check

### DIFF
--- a/js/download_CSV.js
+++ b/js/download_CSV.js
@@ -1,7 +1,7 @@
 function downloadCSV() {
     if (isDownloading) return;
 
-    if (!assertSpeedData('noData', 'Немає даних для завантаження')) return;
+    if (!ensureSpeedData()) return;
 
     isDownloading = true;
     const downloadBtn = document.getElementById('downloadBtn');

--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -14,7 +14,7 @@ function downloadHTML() {
         return;
     }
 
-    if (!assertSpeedData('noData', 'Немає даних для завантаження')) return;
+    if (!ensureSpeedData()) return;
 
     const baseFileName = buildBaseFileName(speedData, operator);
 

--- a/js/download_KML.js
+++ b/js/download_KML.js
@@ -1,5 +1,5 @@
 function downloadKML() {
-    if (!assertSpeedData('noData', 'Немає даних для завантаження')) return;
+    if (!ensureSpeedData()) return;
 
     const baseFileName = buildBaseFileName(speedData, operator);
 

--- a/js/download_utils.js
+++ b/js/download_utils.js
@@ -1,3 +1,7 @@
+function ensureSpeedData() {
+    return assertSpeedData('noData', 'Немає даних для завантаження');
+}
+
 function buildBaseFileName(speedData, operator) {
     const lastRecord = Array.isArray(speedData)
         ? speedData[speedData.length - 1]


### PR DESCRIPTION
## Summary
- add ensureSpeedData helper to centralize speed data assertion
- use ensureSpeedData in CSV, HTML, and KML downloads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895bd1ddbfc8329bdeb05a0d5d6f96b