### PR TITLE
feat: configure IPInfo API

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -23,6 +23,9 @@ const MAX_DATA_POINTS = 60;
 const serverUrl = `https://speed.cloudflare.com/__down?bytes=${TARGET}`;
 const STORAGE_KEY = 'speedData';
 
+export const IPINFO_URL = 'https://ipinfo.io/json';
+export const IPINFO_TOKEN = 'e2a0c701aef96b';
+
 const ICON_RED = 'https://maps.google.com/mapfiles/kml/paddle/red-circle.png';
 const ICON_YELLOW = 'https://maps.google.com/mapfiles/kml/paddle/ylw-circle.png';
 const ICON_GREEN = 'https://maps.google.com/mapfiles/kml/paddle/grn-circle.png';

--- a/js/detect_ISP.js
+++ b/js/detect_ISP.js
@@ -1,7 +1,9 @@
 // Визначення провайдера
+import { IPINFO_URL, IPINFO_TOKEN } from './config.js';
+
 async function detectISP() {
     try {
-        const res = await fetch('https://ipinfo.io/json?token=e2a0c701aef96b');
+        const res = await fetch(`${IPINFO_URL}?token=${IPINFO_TOKEN}`);
         if (!res.ok) {
             throw new Error(`IP info request failed: ${res.status}`);
         }


### PR DESCRIPTION
## Summary
- add IPINFO_URL and IPINFO_TOKEN constants to config
- reuse IPInfo configuration in detect_ISP

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895bfac5a108329bc680d00f6252d29