### PR TITLE
refactor: centralize map constants

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -26,6 +26,9 @@ const STORAGE_KEY = 'speedData';
 export const IPINFO_URL = 'https://ipinfo.io/json';
 export const IPINFO_TOKEN = 'e2a0c701aef96b';
 
+export const MAP_DEFAULT_CENTER = [48.3794, 31.1656];
+export const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+
 const ICON_RED = 'https://maps.google.com/mapfiles/kml/paddle/red-circle.png';
 const ICON_YELLOW = 'https://maps.google.com/mapfiles/kml/paddle/ylw-circle.png';
 const ICON_GREEN = 'https://maps.google.com/mapfiles/kml/paddle/grn-circle.png';

--- a/js/map.js
+++ b/js/map.js
@@ -1,9 +1,10 @@
+import { MAP_DEFAULT_CENTER, OSM_TILE_URL } from './config.js';
 import { getColorBySpeed, ensureColon, addMapMarker } from './map_utils.js';
 
 function initMap() {
     if (mapInitialized) return;
-    map = L.map('map').setView([48.3794, 31.1656], 6);
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    map = L.map('map').setView(MAP_DEFAULT_CENTER, 6);
+    L.tileLayer(OSM_TILE_URL, {
         maxZoom: 19,
         attribution: '© OpenStreetMap'
     }).addTo(map);


### PR DESCRIPTION
## Summary
- define `MAP_DEFAULT_CENTER` and `OSM_TILE_URL` in `config.js`
- import and use map constants in `map.js`

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895c1f23e9083299fd903d552c01bdd