### PR TITLE
refactor: centralize map resource constants

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -29,12 +29,20 @@ export const IPINFO_TOKEN = 'e2a0c701aef96b';
 export const MAP_DEFAULT_CENTER = [48.3794, 31.1656];
 export const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 
+export const LEAFLET_CSS_URL = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css';
+export const LEAFLET_JS_URL = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js';
+export const MARKERCLUSTER_CSS_URL = 'https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css';
+export const MARKERCLUSTER_DEFAULT_CSS_URL = 'https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css';
+export const MARKERCLUSTER_JS_URL = 'https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js';
+
+export const MAP_FALLBACK_CENTER = [50.45, 30.52];
+
 const ICON_RED = 'https://maps.google.com/mapfiles/kml/paddle/red-circle.png';
 const ICON_YELLOW = 'https://maps.google.com/mapfiles/kml/paddle/ylw-circle.png';
 const ICON_GREEN = 'https://maps.google.com/mapfiles/kml/paddle/grn-circle.png';
 
 // Zoom level at which clustering is disabled on the main map
-const DISABLE_CLUSTER_ZOOM = 18;
+export const DISABLE_CLUSTER_ZOOM = 18;
 
 const DEFAULT_DIRECTION_LABELS = {
     uk: ["Пн", "ПнСх", "Сх", "ПдСх", "Пд", "ПдЗх", "Зх", "ПнЗх"],

--- a/js/download_HTML.js
+++ b/js/download_HTML.js
@@ -1,4 +1,14 @@
 import { getColorBySpeed, ensureColon, addMapMarker } from './map_utils.js';
+import {
+    LEAFLET_CSS_URL,
+    LEAFLET_JS_URL,
+    MARKERCLUSTER_CSS_URL,
+    MARKERCLUSTER_DEFAULT_CSS_URL,
+    MARKERCLUSTER_JS_URL,
+    OSM_TILE_URL,
+    MAP_FALLBACK_CENTER,
+    DISABLE_CLUSTER_ZOOM,
+} from './config.js';
 
 function downloadHTML() {
     if (typeof speedData === 'undefined' || !Array.isArray(speedData)) {
@@ -56,17 +66,17 @@ function downloadHTML() {
 <!-- Leaflet CSS -->
 <link
   rel="stylesheet"
-  href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+  href="${LEAFLET_CSS_URL}"
 />
 
 <!-- MarkerCluster CSS -->
 <link
   rel="stylesheet"
-  href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css"
+  href="${MARKERCLUSTER_CSS_URL}"
 />
 <link
   rel="stylesheet"
-  href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css"
+  href="${MARKERCLUSTER_DEFAULT_CSS_URL}"
 />
 
 <style>
@@ -123,16 +133,16 @@ function downloadHTML() {
 <div id="map"></div>
 
 <!-- Leaflet JS -->
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script src="${LEAFLET_JS_URL}"></script>
 <!-- MarkerCluster JS -->
-<script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
+<script src="${MARKERCLUSTER_JS_URL}"></script>
 
 <script>
 /* ------------------ 0. Глобальні значення ------------------ */
 const operator = ${JSON.stringify(operator)};
 const t = (key, fallback = '') => fallback;
 /* ------------------ 1. Параметри ------------------ */
-const DISABLE_CLUSTER_ZOOM = 18; // >= цього зума кластери вимикаються
+const DISABLE_CLUSTER_ZOOM = ${DISABLE_CLUSTER_ZOOM}; // >= цього зума кластери вимикаються
 const COLOR_RED    = 'red';
 const COLOR_YELLOW = 'yellow';
 const COLOR_GREEN  = 'green';
@@ -147,7 +157,7 @@ const data = ${safeData};
 /* ------------------ 4. Ініціалізація карти ------------------ */
 const map = L.map('map');
 const mapMarkers = [];
-const osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+const osm = L.tileLayer('${OSM_TILE_URL}', {
   maxZoom: 19,
   attribution: '© OpenStreetMap contributors'
 });
@@ -197,7 +207,7 @@ const coords = data
 if (coords.length > 0) {
   map.fitBounds(L.latLngBounds(coords).pad(0.05));
 } else {
-  map.setView([50.45, 30.52], 12);
+  map.setView(${JSON.stringify(MAP_FALLBACK_CENTER)}, 12);
 }
 
 /* ------------------ 12. Контроль шарів ------------------ */

--- a/js/map.js
+++ b/js/map.js
@@ -1,4 +1,4 @@
-import { MAP_DEFAULT_CENTER, OSM_TILE_URL } from './config.js';
+import { MAP_DEFAULT_CENTER, OSM_TILE_URL, DISABLE_CLUSTER_ZOOM } from './config.js';
 import { getColorBySpeed, ensureColon, addMapMarker } from './map_utils.js';
 
 function initMap() {


### PR DESCRIPTION
## Summary
- centralize Leaflet, MarkerCluster, tile layer, and fallback center constants in config
- import map constants into download_HTML.js and remove string literals
- reuse DISABLE_CLUSTER_ZOOM across modules

## Testing
- `npm test` *(fails: enoent open '/workspace/gonettest/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6895c3301de08329b40e148bfe518c21