### PR TITLE
feat: centralize network check URL

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -25,6 +25,7 @@ const STORAGE_KEY = 'speedData';
 
 export const IPINFO_URL = 'https://ipinfo.io/json';
 export const IPINFO_TOKEN = 'e2a0c701aef96b';
+export const NETWORK_CHECK_URL = 'https://www.google.com/generate_204';
 
 export const MAP_DEFAULT_CENTER = [48.3794, 31.1656];
 export const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';

--- a/js/speed_test.js
+++ b/js/speed_test.js
@@ -1,4 +1,5 @@
 import { requestWakeLock } from './wake_lock.js';
+import { NETWORK_CHECK_URL } from './config.js';
 
 async function resetTestState() {
     testInProgress = false;
@@ -74,7 +75,7 @@ async function readWithTimeout(reader, timeout = STREAM_READ_TIMEOUT) {
 async function checkRealConnection() {
     try {
         await fetchWithTimeout(
-            'https://www.google.com/generate_204',
+            NETWORK_CHECK_URL,
             { cache: 'no-store', mode: 'no-cors' },
             RECONNECT_TIMEOUT
         );
@@ -235,7 +236,7 @@ async function runTest() {
 // (fetch із bytes=1) проходить успішно — тобто мережа з’явилася.
 async function waitForReconnect() {
   // Використовуємо мінімальний 1-байтовий запит для перевірки доступності
-  const checkUrl = `https://www.google.com/generate_204`;
+  const checkUrl = NETWORK_CHECK_URL;
 
   // Поки тест активний і мережі немає — пробуємо кожні 500 мс відправити маленький запит
   while (testActive && !isConnected) {


### PR DESCRIPTION
## Summary
- define NETWORK_CHECK_URL in config
- use NETWORK_CHECK_URL for connectivity checks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895c45ae2908329b898e7a522f7d65e