### PR TITLE
feat: centralize geojson paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
   <script defer src="translations/en.js"></script>
   <script defer src="translations/uk.js"></script>
 
-  <script defer src="js/config.js"></script>
+  <script type="module" src="js/config.js"></script>
   <script defer src="js/lang.js"></script>
   <script defer src="js/storage.js"></script>
   <script defer src="js/log.js"></script>
@@ -47,7 +47,7 @@
   <script defer src="js/update_stats.js"></script>
   <script type="module" src="js/map.js"></script>
     <script defer src="js/map_zoom.js"></script>
-    <script defer src="js/find_admin_unit.js"></script>
+    <script type="module" src="js/find_admin_unit.js"></script>
     <script defer src="js/change_announcer.js"></script>
     <script defer src="js/hromada_change_announcer.js"></script>
     <script defer src="js/road_change_announcer.js"></script>

--- a/js/config.js
+++ b/js/config.js
@@ -42,6 +42,15 @@ const ICON_RED = 'https://maps.google.com/mapfiles/kml/paddle/red-circle.png';
 const ICON_YELLOW = 'https://maps.google.com/mapfiles/kml/paddle/ylw-circle.png';
 const ICON_GREEN = 'https://maps.google.com/mapfiles/kml/paddle/grn-circle.png';
 
+const HROMADY_GEOJSON = 'data/ukraine_hromady.geojson';
+
+const ROAD_FILES = {
+    international: 'data/international_road_ua_m.geojson',
+    national: 'data/national_road_ua_h.geojson',
+    regional: 'data/regional_road_ua_p.geojson',
+    territorial: 'data/territorial_road_ua_t.geojson',
+};
+
 // Zoom level at which clustering is disabled on the main map
 const DISABLE_CLUSTER_ZOOM = 18;
 
@@ -136,3 +145,87 @@ const operators = {
     'AS15895 "Kyivstar" PJSC': 'Kyivstar',
     'AS34058 Limited Liability Company "lifecell"': 'Lifecell'
 };
+
+export { HROMADY_GEOJSON, ROAD_FILES };
+
+Object.assign(globalThis, {
+    TARGET,
+    MAX_CONSECUTIVE_ERRORS,
+    RECONNECT_TIMEOUT,
+    BIG_FETCH_TIMEOUT,
+    NOTIFICATION_DURATION,
+    BEEP_FREQUENCY,
+    BEEP_DURATION,
+    SPEECH_RATE,
+    GPS_TIMEOUT,
+    GPS_MAX_AGE,
+    MAX_GPS_ACCURACY,
+    MAX_POINT_DISTANCE,
+    DEFAULT_FETCH_TIMEOUT,
+    STREAM_READ_TIMEOUT,
+    UI_UPDATE_INTERVAL,
+    DEFAULT_SAVE_INTERVAL,
+    RECONNECT_RETRY_INTERVAL,
+    RUN_LOOP_PAUSE,
+    ORIENTATION_DELAY,
+    MAX_DATA_POINTS,
+    serverUrl,
+    STORAGE_KEY,
+    IPINFO_URL,
+    IPINFO_TOKEN,
+    NETWORK_CHECK_URL,
+    MAP_DEFAULT_CENTER,
+    OSM_TILE_URL,
+    LEAFLET_CSS_URL,
+    LEAFLET_JS_URL,
+    MARKERCLUSTER_CSS_URL,
+    MARKERCLUSTER_DEFAULT_CSS_URL,
+    MARKERCLUSTER_JS_URL,
+    MAP_FALLBACK_CENTER,
+    ICON_RED,
+    ICON_YELLOW,
+    ICON_GREEN,
+    HROMADY_GEOJSON,
+    ROAD_FILES,
+    DISABLE_CLUSTER_ZOOM,
+    DEFAULT_DIRECTION_LABELS,
+    currentLang,
+    testActive,
+    totalBytes,
+    prevBytes,
+    startTime,
+    updateInterval,
+    consecutiveErrors,
+    isConnected,
+    isFullscreen,
+    testInProgress,
+    pendingRun,
+    activeDownloadController,
+    isDownloading,
+    speedData,
+    dataInterval,
+    lastSavedBytes,
+    currentSpeedMbps,
+    currentGPSData,
+    lastSavedGPSData,
+    gpsWatchId,
+    totalDistance,
+    settings,
+    speedChart,
+    chartData,
+    maxDataPoints,
+    map,
+    mapMarkers,
+    mapInitialized,
+    hromadyLayer,
+    internationalRoadLayer,
+    nationalRoadLayer,
+    regionalRoadLayer,
+    territorialRoadLayer,
+    redCluster,
+    yellowCluster,
+    greenCluster,
+    speedStats,
+    operator,
+    operators,
+});

--- a/js/find_admin_unit.js
+++ b/js/find_admin_unit.js
@@ -1,3 +1,5 @@
+import { HROMADY_GEOJSON, ROAD_FILES } from './config.js';
+
 // Global variable to hold the GeoJSON data for hromady (communities)
 let hromadyData = null;
 let hromadyDataPromise = null;
@@ -6,7 +8,7 @@ let hromadyDataPromise = null;
 // Returns a promise that resolves when the data is loaded.
 function loadHromadyData() {
     if (!hromadyDataPromise) {
-        hromadyDataPromise = fetch('data/ukraine_hromady.geojson')
+        hromadyDataPromise = fetch(HROMADY_GEOJSON)
             .then(r => r.json())
             .then(data => {
                 hromadyData = data;
@@ -109,13 +111,6 @@ async function find_admin_unit(lon, lat) {
 
 // ----- Road lookup functionality -----
 
-const roadFiles = {
-    international: 'data/international_road_ua_m.geojson',
-    national: 'data/national_road_ua_h.geojson',
-    regional: 'data/regional_road_ua_p.geojson',
-    territorial: 'data/territorial_road_ua_t.geojson'
-};
-
 const roadData = {
     international: null,
     national: null,
@@ -127,7 +122,7 @@ const roadPromises = {};
 
 function loadRoadData(type) {
     if (!roadPromises[type]) {
-        roadPromises[type] = fetch(roadFiles[type])
+        roadPromises[type] = fetch(ROAD_FILES[type])
             .then(r => r.json())
             .then(data => {
                 roadData[type] = data;
@@ -142,7 +137,7 @@ function loadRoadData(type) {
 }
 
 function loadAllRoadData() {
-    return Promise.all(Object.keys(roadFiles).map(loadRoadData));
+    return Promise.all(Object.keys(ROAD_FILES).map(loadRoadData));
 }
 
 function latLonToXY(lat, lon) {
@@ -209,3 +204,7 @@ function find_road(lat, lon, threshold = 50) {
     }
     return null;
 }
+
+export { loadHromadyData, find_admin_unit, loadAllRoadData, find_road, roadData };
+
+Object.assign(window, { loadHromadyData, find_admin_unit, loadAllRoadData, find_road, roadData });

--- a/js/map.js
+++ b/js/map.js
@@ -1,4 +1,5 @@
 import { getColorBySpeed, ensureColon, addMapMarker } from './map_utils.js';
+import { HROMADY_GEOJSON, ROAD_FILES } from './config.js';
 
 function initMap() {
     if (mapInitialized) return;
@@ -155,7 +156,7 @@ function updateHromadyLayer() {
         if (hromadyLayer) {
             hromadyLayer.addTo(map);
         } else {
-            fetch('data/ukraine_hromady.geojson')
+            fetch(HROMADY_GEOJSON)
                 .then(r => r.json())
                 .then(data => {
                     hromadyLayer = L.geoJSON(data, { style: { color: '#555', weight: 1 } }).addTo(map);
@@ -180,7 +181,7 @@ function updateInternationalRoadLayer() {
         if (internationalRoadLayer) {
             internationalRoadLayer.addTo(map);
         } else {
-            fetch('data/international_road_ua_m.geojson')
+            fetch(ROAD_FILES.international)
                 .then(r => r.json())
                 .then(data => {
                     internationalRoadLayer = L.geoJSON(data, {
@@ -200,7 +201,7 @@ function updateNationalRoadLayer() {
         if (nationalRoadLayer) {
             nationalRoadLayer.addTo(map);
         } else {
-            fetch('data/national_road_ua_h.geojson')
+            fetch(ROAD_FILES.national)
                 .then(r => r.json())
                 .then(data => {
                     nationalRoadLayer = L.geoJSON(data, {
@@ -220,7 +221,7 @@ function updateRegionalRoadLayer() {
         if (regionalRoadLayer) {
             regionalRoadLayer.addTo(map);
         } else {
-            fetch('data/regional_road_ua_p.geojson')
+            fetch(ROAD_FILES.regional)
                 .then(r => r.json())
                 .then(data => {
                     regionalRoadLayer = L.geoJSON(data, {
@@ -240,7 +241,7 @@ function updateTerritorialRoadLayer() {
         if (territorialRoadLayer) {
             territorialRoadLayer.addTo(map);
         } else {
-            fetch('data/territorial_road_ua_t.geojson')
+            fetch(ROAD_FILES.territorial)
                 .then(r => r.json())
                 .then(data => {
                     territorialRoadLayer = L.geoJSON(data, {


### PR DESCRIPTION
## Summary
- centralize GeoJSON path constants in config
- consume HROMADY_GEOJSON and ROAD_FILES constants in map and admin unit lookup
- load config and admin unit scripts as modules

## Testing
- `node --check --experimental-default-type=module js/config.js`
- `node --check --experimental-default-type=module js/map.js`
- `node --check --experimental-default-type=module js/find_admin_unit.js`


------
https://chatgpt.com/codex/tasks/task_e_6895c7885f088329965ec6c8047f96c2