### PR TITLE
Expose cluster zoom config

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -146,7 +146,7 @@ const operators = {
     'AS34058 Limited Liability Company "lifecell"': 'Lifecell'
 };
 
-export { HROMADY_GEOJSON, ROAD_FILES };
+export { HROMADY_GEOJSON, ROAD_FILES, DISABLE_CLUSTER_ZOOM };
 
 Object.assign(globalThis, {
     TARGET,


### PR DESCRIPTION
## Summary
- export DISABLE_CLUSTER_ZOOM constant from js/config.js so other modules can import it

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/gonettest/package.json')*
- `npm run build` *(fails: ENOENT: no such file or directory, open '/workspace/gonettest/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_6895ccd2cbc083299ba9622a60876911