### PR TITLE
Expose calculateDistance for other modules

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -282,3 +282,4 @@ window.updateHromadyLayer = updateHromadyLayer;
 window.updateRoadLayers = updateRoadLayers;
 window.setupMapObserver = setupMapObserver;
 window.initMapIfNeeded = initMapIfNeeded;
+window.calculateDistance = calculateDistance;


### PR DESCRIPTION
## Summary
- Expose `calculateDistance` globally so other scripts can access it

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895e47658f0832995edfe5435af527e