### PR TITLE
Fix road coverage percentage calculation

### DIFF
--- a/js/update_road_stats.js
+++ b/js/update_road_stats.js
@@ -64,7 +64,7 @@ function updateRoadStats() {
         const zl = s.length ? Math.round((zKm / s.length) * 100) : 0;
         const ul = s.length ? Math.round((uKm / s.length) * 100) : 0;
         const al = s.length ? Math.round((aKm / s.length) * 100) : 0;
-        const tl = s.length ? Math.round((coveredKm / s.total) * 100) : 0;
+        const tl = s.length ? Math.round((coveredKm / s.length) * 100) : 0;
         const lenUnit = currentLang === 'uk' ? 'км' : 'km';
         const lenStr = coveredKm ? `${coveredKm.toFixed(1)} ${lenUnit}` : '-';
         const roadLenStr = coveredKm ? `${lenStr} (${tl}%)` : '-';


### PR DESCRIPTION
## Summary
- derive distance coverage percentage by dividing measured distance by road length

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896ed6b2bc08329936ed812479161b9