### PR TITLE
Simplify road stats header

### DIFF
--- a/js/update_road_stats.js
+++ b/js/update_road_stats.js
@@ -69,7 +69,7 @@ function updateRoadStats() {
         const lenStr = coveredKm ? `${coveredKm.toFixed(1)} ${lenUnit}` : '-';
         const roadLenStr = coveredKm ? `${lenStr} (${tl}%)` : '-';
         rows.push(
-            `<div class="info-row road-toggle" data-target="${roadId}"><span><i data-lucide="plus"></i> ${road} тестів (відстань км)</span><span>${s.total} (${lenStr})</span></div>` +
+            `<div class="info-row road-toggle" data-target="${roadId}"><span><i data-lucide="plus"></i> ${road}</span><span>${s.total} (${lenStr})</span></div>` +
             `<div id="${roadId}" class="road-content hidden" style="padding-left:20px">` +
             `<div class="info-row"><span>${t('testsPercentTotal', 'Тестів:')}</span><span>${s.total}</span></div>` +
             `<div class="info-row"><span>${t('zeroSpeedLabel', '0 Мбіт/с (% від загальної кількості):')}</span><span>${s.zero} (${zp}%)</span></div>` +


### PR DESCRIPTION
## Summary
- Remove hardcoded "tests (distance km)" text from road stats rows, leaving only the road name

## Testing
- `node --check js/update_road_stats.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896efdaf4548329927e23104965b9fe