### PR TITLE
refactor admin stats row

### DIFF
--- a/js/update_admin_stats.js
+++ b/js/update_admin_stats.js
@@ -57,10 +57,11 @@ function updateAdminStats() {
     }
 
     const statsRows = (obj, indent) => {
+        const totalKm = calcTotalKm(obj);
         const unit = currentLang === 'uk' ? 'км' : 'km';
         return (
             countRows(obj, indent) +
-            `<div class="info-row" style="--indent:${indent}px"><span>${t('distanceKmLabel', 'Відстань')}</span><span>${calcTotalKm(obj)} ${unit}</span></div>` +
+            `<div class="info-row" style="--indent:${indent}px"><span>${t('distanceKmLabel', 'Відстань')}</span><span>${totalKm} ${unit}</span></div>` +
             distRows(obj, indent)
         );
     };


### PR DESCRIPTION
## Summary
- compute total kilometers within `statsRows` using `calcTotalKm(obj)`
- keep `statsRows` callers simple by passing only the object and indent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689709d78b008329a47fe49dd3f19fa3