### PR TITLE
Validate speed and distance in stats utils

### DIFF
--- a/js/stats_utils.js
+++ b/js/stats_utils.js
@@ -1,5 +1,22 @@
 function accumulateSpeedStats(target, speed, distance) {
-    const dist = distance || 0;
+    if (!Number.isFinite(speed)) {
+        if (typeof addLog === 'function') {
+            addLog(`accumulateSpeedStats: invalid speed ${speed}`);
+        }
+        return;
+    }
+
+    let dist = 0;
+    if (distance !== undefined) {
+        if (!Number.isFinite(distance) || distance < 0) {
+            if (typeof addLog === 'function') {
+                addLog(`accumulateSpeedStats: invalid distance ${distance}`);
+            }
+        } else {
+            dist = distance;
+        }
+    }
+
     target.total++;
     if (speed === 0) {
         target.zero++;


### PR DESCRIPTION
## Summary
- ensure `accumulateSpeedStats` ignores invalid speed values
- clamp or warn about invalid or negative distance values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689712bc19ec832991863041a1f06075