### PR TITLE
Add translation for records count in admin stats

### DIFF
--- a/js/update_admin_stats.js
+++ b/js/update_admin_stats.js
@@ -104,7 +104,7 @@ function updateAdminStats() {
     const countRows = (obj, depth) => {
         const indent = calcIndent(depth);
         return (
-            `<div class="info-row" style="--indent:${indent}px"><span>Записів:</span><span>${obj.zero + obj.upto2 + obj.above2}</span></div>` +
+            `<div class="info-row" style="--indent:${indent}px"><span>${t('recordsLabel', 'Записів')}:</span><span>${obj.zero + obj.upto2 + obj.above2}</span></div>` +
             `<div class="info-row" style="--indent:${indent}px"><span>${t('zeroSpeedLabel', '0 Мбіт/с:')}</span><span>${obj.zero} (${pct(obj.zero, obj.total)}%)</span></div>` +
             `<div class="info-row" style="--indent:${indent}px"><span>${t('upTo2SpeedLabel', 'До 2 Мбіт/с:')}</span><span>${obj.upto2} (${pct(obj.upto2, obj.total)}%)</span></div>` +
             `<div class="info-row" style="--indent:${indent}px"><span>${t('above2SpeedLabel', 'Більше 2 Мбіт/с:')}</span><span>${obj.above2} (${pct(obj.above2, obj.total)}%)</span></div>`

--- a/translations/en.js
+++ b/translations/en.js
@@ -53,6 +53,7 @@ window.i18n.en = {
   providerInfoTitle: "Provider details",
   latestMeasurementsTitle: "Database",
   recordsCount: "Records:",
+  recordsLabel: "Records",
   dbTitle: "Statistics database",
   dbRecordsLabel: "Records",
   dbSizeLabel: "Size",

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -53,6 +53,7 @@ window.i18n.uk = {
   providerInfoTitle: "Детальна інформація про провайдера",
   latestMeasurementsTitle: "База даних",
   recordsCount: "Записів:",
+  recordsLabel: "Записів",
   dbTitle: "Статистика бази даних",
   dbRecordsLabel: "Записів",
   dbSizeLabel: "Розмір",


### PR DESCRIPTION
## Summary
- localize "Records" label in admin stats using translation function
- add `recordsLabel` translations in English and Ukrainian resources

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689719abe71883298aae540cdcfdfdd6