### PR TITLE
fix admin stats count sum precision

### DIFF
--- a/js/update_admin_stats.js
+++ b/js/update_admin_stats.js
@@ -103,7 +103,7 @@ function updateAdminStats() {
     const pct = (v, tot) => (tot ? Math.round((v / tot) * 100) : 0);
     const countRows = (obj, depth) => {
         const indent = calcIndent(depth);
-        const sum = (obj.zero + obj.upto2 + obj.above2).toFixed(1);
+        const sum = obj.zero + obj.upto2 + obj.above2;
         if (obj.total !== sum) {
             console.warn(`Mismatch in total count: ${obj.total} vs ${sum}`);
         }


### PR DESCRIPTION
## Summary
- keep `countRows` total check numeric by removing `.toFixed(1)` when summing speeds

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897724c3cf08329b61d86a31182b7b3