### PR TITLE
Parse and validate distance in road stats

### DIFF
--- a/js/update_road_stats.js
+++ b/js/update_road_stats.js
@@ -48,8 +48,8 @@ function updateRoadStats() {
             };
         }
         const s = stats[ref];
-        const dist = Number(rec.distance);
-        const validDist = Number.isFinite(dist) ? dist : 0;
+        const dist = Number(rec.distance) || 0;
+        const validDist = Number.isFinite(dist) && dist >= 0 ? dist : 0;
         accumulateSpeedStats(s, rec.speed, validDist);
     }
 


### PR DESCRIPTION
## Summary
- Parse road test distance values as numbers before accumulating stats
- Ignore negative or non-finite distances when computing road metrics

## Testing
- `node --check js/update_road_stats.js`


------
https://chatgpt.com/codex/tasks/task_e_689775459d5483299e3117ac27e76280