### PR TITLE
Add distance calculations to speed distribution stats

### DIFF
--- a/js/update_speed_distribution.js
+++ b/js/update_speed_distribution.js
@@ -1,24 +1,26 @@
 function updateSpeedDistribution() {
-    let total = 0,
-        zero = 0,
-        upTo2 = 0,
-        above2 = 0;
+    const stats = {
+        total: 0,
+        zero: 0,
+        upto2: 0,
+        above2: 0,
+        distZero: 0,
+        distUpto2: 0,
+        distAbove2: 0,
+    };
+
     for (const rec of speedData) {
         const speed = rec.speed;
         if (typeof speed !== "number" || speed < 0 || Number.isNaN(speed)) {
             continue;
         }
-        total++;
-        if (speed === 0) {
-            zero++;
-        } else if (speed > 0 && speed <= 2) {
-            upTo2++;
-        } else if (speed > 2) {
-            above2++;
-        }
+        const dist = Number(rec.distance);
+        const validDist = Number.isFinite(dist) && dist >= 0 ? dist : 0;
+        accumulateSpeedStats(stats, speed, validDist);
     }
 
-    const set = (id, count) => {
+    const total = stats.total;
+    const setCount = (id, count) => {
         const el = document.getElementById(id);
         if (el) {
             const percent = total ? Math.round((count / total) * 100) : 0;
@@ -26,9 +28,30 @@ function updateSpeedDistribution() {
         }
     };
 
-    set("allSpeedCount", total);
-    set("zeroSpeedCount", zero);
-    set("upto2SpeedCount", upTo2);
-    set("above2SpeedCount", above2);
+    setCount("allSpeedCount", stats.total);
+    setCount("zeroSpeedCount", stats.zero);
+    setCount("upto2SpeedCount", stats.upto2);
+    setCount("above2SpeedCount", stats.above2);
+
+    const totalDist = stats.distZero + stats.distUpto2 + stats.distAbove2;
+    const unit = typeof currentLang !== 'undefined' && currentLang === 'en' ? 'km' : 'км';
+
+    const setDist = (id, dist, showPercent = true) => {
+        const el = document.getElementById(id);
+        if (el) {
+            const km = dist / 1000;
+            if (showPercent) {
+                const percent = totalDist ? Math.round((dist / totalDist) * 100) : 0;
+                el.textContent = `${km.toFixed(1)} ${unit} (${percent}%)`;
+            } else {
+                el.textContent = `${km.toFixed(1)} ${unit}`;
+            }
+        }
+    };
+
+    setDist("allDist", totalDist, false);
+    setDist("distZero", stats.distZero);
+    setDist("distUpto2", stats.distUpto2);
+    setDist("distAbove2", stats.distAbove2);
 }
 


### PR DESCRIPTION
## Summary
- include distance accumulation per speed category in `updateSpeedDistribution`
- display total covered distance and percentage split for each speed class

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68982e0cfa088329bbfbab65842c35c4