### PR TITLE
Fix records count translation key

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,7 +363,7 @@
       <div class="info" id="speedStats">
         <div class="fw-bold mb-10" data-i18n="speedStatsTitle">Статистика швидкості завантаження</div>
         <div class="info-row">
-          <span data-i18n="zeroSpeedLabelrecordsCount">Записів:</span>
+          <span data-i18n="recordsCount">Записів:</span>
           <span id="allSpeedCount">0</span>
         </div>
         <div class="info-row">


### PR DESCRIPTION
## Summary
- use existing `recordsCount` i18n key in speed stats section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689838cd30d083298cc3ec668feff18f