### PR TITLE
Fix stray character in road stats updater

### DIFF
--- a/js/update_road_stats.js
+++ b/js/update_road_stats.js
@@ -75,7 +75,7 @@ function updateRoadStats() {
         const al = s.length ? Math.round((aKm / s.length) * 100) : 0;
         const tl = s.length ? Math.round((coveredKm / s.length) * 100) : 0;
         const lenUnit = currentLang === 'uk' ? 'км' : 'km';
-        const lenStr = coveredKm ? `${coveredKm.toFixed(1)} ${lenUnit}` : '-';я
+        const lenStr = coveredKm ? `${coveredKm.toFixed(1)} ${lenUnit}` : '-';
         const roadLenStr = coveredKm ? `${lenStr} (${tl}%)` : '-';
         const zpStr = s.total > 0 ? `${zp}%` : '0%';
         const upStr = s.total > 0 ? `${up}%` : '0%';


### PR DESCRIPTION
## Summary
- remove stray `я` character from `update_road_stats.js` to restore valid syntax

## Testing
- `node --check js/update_road_stats.js`
- node script verifying road and administrative-unit stats populate

------
https://chatgpt.com/codex/tasks/task_e_689a3290b88883298cf8e844f747bc7f