### PR TITLE
Handle updateRoadStats failures

### DIFF
--- a/js/update_database_info.js
+++ b/js/update_database_info.js
@@ -80,7 +80,11 @@ function updateDatabaseInfo() {
     }
 
     if (typeof updateRoadStats === 'function') {
-        updateRoadStats();
+        try {
+            updateRoadStats();
+        } catch (err) {
+            console.error('updateRoadStats failed', err);
+        }
     }
     if (typeof updateAdminStats === "function") {
         updateAdminStats();


### PR DESCRIPTION
## Summary
- protect admin statistics from road stats failures
- log errors from `updateRoadStats` while still invoking `updateAdminStats`

## Testing
- `node --check js/update_database_info.js`
- Simulated reload with failing `updateRoadStats` confirming `updateAdminStats` still runs

------
https://chatgpt.com/codex/tasks/task_e_689a344c42d48329a4fc5caa313c8c2f