### PR TITLE
refactor: compute total distance once

### DIFF
--- a/js/update_admin_stats.js
+++ b/js/update_admin_stats.js
@@ -116,10 +116,11 @@ function updateAdminStats() {
     };
     const distRows = (obj, depth) => {
         const indent = calcIndent(depth);
+        const totalDist = obj.distZero + obj.distUpto2 + obj.distAbove2;
         return (
-            `<div class="info-row" style="--indent:${indent}px"><span>${t('zeroSpeedLabel2', '0 Мбіт/с (% від протяжності):')}</span><span>${(obj.distZero / 1000).toFixed(1)} ${unit} (${pct(obj.distZero, obj.distZero + obj.distUpto2 + obj.distAbove2)}%)</span></div>` +
-            `<div class="info-row" style="--indent:${indent}px"><span>${t('upTo2SpeedLabel2', 'До 2 Мбіт/с (% від протяжності):')}</span><span>${(obj.distUpto2 / 1000).toFixed(1)} ${unit} (${pct(obj.distUpto2, obj.distZero + obj.distUpto2 + obj.distAbove2)}%)</span></div>` +
-            `<div class="info-row" style="--indent:${indent}px"><span>${t('above2SpeedLabel2', 'Більше 2 Мбіт/с (% від протяжності):')}</span><span>${(obj.distAbove2 / 1000).toFixed(1)} ${unit} (${pct(obj.distAbove2, obj.distZero + obj.distUpto2 + obj.distAbove2)}%)</span></div>`
+            `<div class="info-row" style="--indent:${indent}px"><span>${t('zeroSpeedLabel2', '0 Мбіт/с (% від протяжності):')}</span><span>${(obj.distZero / 1000).toFixed(1)} ${unit} (${pct(obj.distZero, totalDist)}%)</span></div>` +
+            `<div class="info-row" style="--indent:${indent}px"><span>${t('upTo2SpeedLabel2', 'До 2 Мбіт/с (% від протяжності):')}</span><span>${(obj.distUpto2 / 1000).toFixed(1)} ${unit} (${pct(obj.distUpto2, totalDist)}%)</span></div>` +
+            `<div class="info-row" style="--indent:${indent}px"><span>${t('above2SpeedLabel2', 'Більше 2 Мбіт/с (% від протяжності):')}</span><span>${(obj.distAbove2 / 1000).toFixed(1)} ${unit} (${pct(obj.distAbove2, totalDist)}%)</span></div>`
         );
     };
     


### PR DESCRIPTION
## Summary
- refactor: compute total distance once in distRows and reuse for percentage calculations

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c85e957f48329931753de778f1a6a