### PR TITLE
Handle missing speed data in road stats

### DIFF
--- a/js/update_road_stats.js
+++ b/js/update_road_stats.js
@@ -32,8 +32,16 @@ function getRoadLength(ref) {
 }
 
 function updateRoadStats() {
+    const wrapper = document.getElementById('roadStats');
     const container = document.getElementById('roadStatsContent');
-    if (!container) return;
+    if (!wrapper || !container) return;
+
+    if (!Array.isArray(speedData) || speedData.length === 0) {
+        wrapper.style.display = 'none';
+        container.innerHTML = '';
+        return;
+    }
+    wrapper.style.display = '';
 
     const stats = {};
     for (const rec of speedData) {


### PR DESCRIPTION
## Summary
- Guard road stats against missing or empty speed data and hide wrapper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c8bec0490832995344f6ce1b11347