### PR TITLE
Add speed camera map layer toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,6 +189,12 @@
         </div>
       </div>
       <div class="setting-group">
+        <div class="checkbox-group">
+          <input type="checkbox" id="showSpeedCameras" />
+          <label class="setting-label" for="showSpeedCameras" data-i18n="showSpeedCamerasLabel">Міжнародні дороги</label>
+        </div>
+      </div>
+      <div class="setting-group">
         <label class="setting-label" for="languageSelect" data-i18n="languageLabel">Мова</label>
         <select id="languageSelect" class="setting-input" onchange="setLanguage(this.value)">
           <option value="uk">Українська</option>

--- a/js/config.js
+++ b/js/config.js
@@ -51,6 +51,8 @@ const ROAD_FILES = {
     territorial: 'data/territorial_road_ua_t.geojson',
 };
 
+const SPEED_CAMERA_FILE = 'data/speed_camera_coordinates.json';
+
 // Zoom level at which clustering is disabled on the main map
 const DISABLE_CLUSTER_ZOOM = 18;
 
@@ -110,6 +112,7 @@ let settings = {
     showNationalRoads: false,
     showRegionalRoads: false,
     showTerritorialRoads: false,
+    showSpeedCameras: false,
 };
 
 // Графік
@@ -126,6 +129,7 @@ let internationalRoadLayer = null;
 let nationalRoadLayer = null;
 let regionalRoadLayer = null;
 let territorialRoadLayer = null;
+let speedCameraLayer = null;
 let redCluster = null;
 let yellowCluster = null;
 let greenCluster = null;
@@ -146,7 +150,7 @@ const operators = {
     'AS34058 Limited Liability Company "lifecell"': 'Lifecell'
 };
 
-export { HROMADY_GEOJSON, ROAD_FILES, DISABLE_CLUSTER_ZOOM };
+export { HROMADY_GEOJSON, ROAD_FILES, DISABLE_CLUSTER_ZOOM, SPEED_CAMERA_FILE };
 
 Object.assign(globalThis, {
     TARGET,
@@ -187,6 +191,7 @@ Object.assign(globalThis, {
     ICON_GREEN,
     HROMADY_GEOJSON,
     ROAD_FILES,
+    SPEED_CAMERA_FILE,
     DISABLE_CLUSTER_ZOOM,
     DEFAULT_DIRECTION_LABELS,
     currentLang,
@@ -222,6 +227,7 @@ Object.assign(globalThis, {
     nationalRoadLayer,
     regionalRoadLayer,
     territorialRoadLayer,
+    speedCameraLayer,
     redCluster,
     yellowCluster,
     greenCluster,

--- a/js/map.js
+++ b/js/map.js
@@ -1,5 +1,5 @@
 import { getColorBySpeed, ensureColon, addMapMarker } from './map_utils.js';
-import { HROMADY_GEOJSON, ROAD_FILES } from './config.js';
+import { HROMADY_GEOJSON, ROAD_FILES, SPEED_CAMERA_FILE } from './config.js';
 
 function initMap() {
     if (mapInitialized) return;
@@ -174,6 +174,7 @@ function updateRoadLayers() {
     updateNationalRoadLayer();
     updateRegionalRoadLayer();
     updateTerritorialRoadLayer();
+    updateSpeedCameraLayer();
 }
 
 function updateInternationalRoadLayer() {
@@ -253,6 +254,35 @@ function updateTerritorialRoadLayer() {
         }
     } else if (territorialRoadLayer) {
         map.removeLayer(territorialRoadLayer);
+    }
+}
+
+function updateSpeedCameraLayer() {
+    if (settings.showSpeedCameras) {
+        if (speedCameraLayer) {
+            speedCameraLayer.addTo(map);
+        } else {
+            fetch(SPEED_CAMERA_FILE)
+                .then(r => r.json())
+                .then(data => {
+                    const markers = data
+                        .map(item => {
+                            const lat = item["Широта"];
+                            const lon = item["Довгота"];
+                            if (lat == null || lon == null) return null;
+                            const marker = L.marker([lat, lon]);
+                            if (item["Адреса"]) {
+                                marker.bindPopup(item["Адреса"]);
+                            }
+                            return marker;
+                        })
+                        .filter(Boolean);
+                    speedCameraLayer = L.layerGroup(markers).addTo(map);
+                })
+                .catch(err => console.error('Speed camera load failed', err));
+        }
+    } else if (speedCameraLayer) {
+        map.removeLayer(speedCameraLayer);
     }
 }
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -43,6 +43,7 @@ function saveSettings() {
     const showNationalRoads = panel.querySelector("#showNationalRoads");
     const showRegionalRoads = panel.querySelector("#showRegionalRoads");
     const showTerritorialRoads = panel.querySelector("#showTerritorialRoads");
+    const showSpeedCameras = panel.querySelector("#showSpeedCameras");
     const langSelect = panel.querySelector("#languageSelect");
 
     if (soundAlerts) settings.soundAlerts = soundAlerts.checked; else console.warn("soundAlerts element not found");
@@ -54,6 +55,7 @@ function saveSettings() {
     if (showNationalRoads) settings.showNationalRoads = showNationalRoads.checked; else console.warn("showNationalRoads element not found");
     if (showRegionalRoads) settings.showRegionalRoads = showRegionalRoads.checked; else console.warn("showRegionalRoads element not found");
     if (showTerritorialRoads) settings.showTerritorialRoads = showTerritorialRoads.checked; else console.warn("showTerritorialRoads element not found");
+    if (showSpeedCameras) settings.showSpeedCameras = showSpeedCameras.checked; else console.warn("showSpeedCameras element not found");
     if (langSelect) setLanguage(langSelect.value); else console.warn("languageSelect element not found");
 
     // Перезапускаємо інтервал збереження якщо тест активний
@@ -94,6 +96,7 @@ function loadSettings() {
     const showNationalRoads = panel.querySelector("#showNationalRoads");
     const showRegionalRoads = panel.querySelector("#showRegionalRoads");
     const showTerritorialRoads = panel.querySelector("#showTerritorialRoads");
+    const showSpeedCameras = panel.querySelector("#showSpeedCameras");
     const langSelect = panel.querySelector("#languageSelect");
 
     if (soundAlerts) soundAlerts.checked = settings.soundAlerts; else console.warn("soundAlerts element not found");
@@ -105,5 +108,6 @@ function loadSettings() {
     if (showNationalRoads) showNationalRoads.checked = settings.showNationalRoads; else console.warn("showNationalRoads element not found");
     if (showRegionalRoads) showRegionalRoads.checked = settings.showRegionalRoads; else console.warn("showRegionalRoads element not found");
     if (showTerritorialRoads) showTerritorialRoads.checked = settings.showTerritorialRoads; else console.warn("showTerritorialRoads element not found");
+    if (showSpeedCameras) showSpeedCameras.checked = settings.showSpeedCameras; else console.warn("showSpeedCameras element not found");
     if (langSelect) langSelect.value = currentLang; else console.warn("languageSelect element not found");
 }

--- a/translations/en.js
+++ b/translations/en.js
@@ -23,6 +23,7 @@ window.i18n.en = {
   showNationalRoadsLabel: "National roads",
   showRegionalRoadsLabel: "Regional roads",
   showTerritorialRoadsLabel: "Territorial roads",
+  showSpeedCamerasLabel: "Speed cameras",
   languageLabel: "Language",
   saveSettingsButton: "Save settings",
   currentSpeedLabel: "Current download speed Mbps",

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -23,6 +23,7 @@ window.i18n.uk = {
   showNationalRoadsLabel: "Національні дороги",
   showRegionalRoadsLabel: "Регіональні дороги",
   showTerritorialRoadsLabel: "Територіальні дороги",
+  showSpeedCamerasLabel: "Камери контролю швидкості",
   languageLabel: "Мова",
   saveSettingsButton: "Зберегти налаштування",
   currentSpeedLabel: "Поточна швидкість завантаження Мбіт/с",


### PR DESCRIPTION
## Summary
- Add UI toggle and translations for displaying speed camera markers
- Persist speed camera setting and load JSON data on the map
- Introduce configuration and map logic to render speed camera layer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cd38e9c4483299a2b333354e01a9a