### PR TITLE
Export per-record download delta

### DIFF
--- a/js/download_CSV.js
+++ b/js/download_CSV.js
@@ -19,7 +19,7 @@ function downloadCSV() {
             "Дорога;" +
             "Оператор;" +
             "Швидкість (Мбіт/с);" +
-            "Сумарно завантажено (МБ);" +
+            "Завантажено від попереднього запису (МБ);" +
             "Тривалість (с);" +
             "Широта;" +
             "Довгота;" +
@@ -29,7 +29,6 @@ function downloadCSV() {
             "Точність (м);" +
             "Напрямок (°)\n";
 
-        let cumulative = 0;
         const csvContent =
             headers +
             speedData
@@ -51,7 +50,7 @@ function downloadCSV() {
                         `${record.roadRef || ""};` +
                         `${operator};` +
                         `${record.speed.toFixed(2)};` +
-                        `${(cumulative += record.downloadedDelta).toFixed(2)};` +
+                        `${record.downloadedDelta.toFixed(2)};` +
                         `${record.elapsed ?? ""};` +
                         `${record.latitude ?? ""};` +
                         `${record.longitude ?? ""};` +

--- a/js/download_KML.js
+++ b/js/download_KML.js
@@ -11,7 +11,6 @@ function downloadKML() {
         `<Style id="red"><IconStyle><Icon><href>${ICON_RED}</href></Icon></IconStyle></Style>\n` +
         `<Style id="yellow"><IconStyle><Icon><href>${ICON_YELLOW}</href></Icon></IconStyle></Style>\n` +
         `<Style id="green"><IconStyle><Icon><href>${ICON_GREEN}</href></Icon></IconStyle></Style>\n`;
-    let cumulative = 0;
 
     speedData.forEach((record, idx) => {
         if (record.latitude == null || record.longitude == null) return;
@@ -23,7 +22,6 @@ function downloadKML() {
             );
             return;
         }
-        cumulative += Number(record.downloadedDelta) || 0;
 
         const altitude =
             record.altitude != null ? record.altitude.toFixed(1) : (0).toFixed(1);
@@ -40,7 +38,7 @@ function downloadKML() {
             `Час: ${timeStr}<br>` +
             `Оператор: ${operator}<br>` +
             `Швидкість (Мбіт/с): ${record.speed.toFixed(2)}<br>` +
-            `Завантажено (МБ): ${cumulative.toFixed(2)}<br>` +
+            `Завантажено від попереднього запису (МБ): ${record.downloadedDelta.toFixed(2)}<br>` +
             `Тривалість (с): ${record.elapsed ?? ''}<br>` +
             `Широта: ${record.latitude}<br>` +
             `Довгота: ${record.longitude}<br>` +


### PR DESCRIPTION
## Summary
- Export per-record download delta in CSV with updated header
- Use per-point download delta in KML descriptions

## Testing
- `node --check js/download_CSV.js js/download_KML.js js/data_point.js`


------
https://chatgpt.com/codex/tasks/task_e_689cd9999c6c8329b78f2e0fc030349c