### PR TITLE
Track elapsed time between saved points

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -82,6 +82,7 @@ let isDownloading = false;
 let speedData = [];
 let dataInterval = null;
 let lastSavedBytes = 0;
+let lastSavedTime = 0;
 let currentSpeedMbps = 0;
 let currentGPSData = {
     latitude: null,
@@ -210,6 +211,7 @@ Object.assign(globalThis, {
     speedData,
     dataInterval,
     lastSavedBytes,
+    lastSavedTime,
     currentSpeedMbps,
     currentGPSData,
     lastSavedGPSData,

--- a/js/data_point.js
+++ b/js/data_point.js
@@ -51,7 +51,7 @@ async function saveDataPoint() {
     );
 
     const now = new Date();
-    const elapsed = (Date.now() - startTime) / 1000;
+    const elapsed = (Date.now() - lastSavedTime) / 1000;
 
     // Обчислюємо відстань для додавання до загальної
     let pointDistance = getDistanceToLastPoint(
@@ -86,6 +86,7 @@ async function saveDataPoint() {
 
     speedData.push(dataPoint);
     lastSavedBytes = totalBytes;
+    lastSavedTime = now.getTime();
     saveSpeedDataToStorage();
     addMapMarker(dataPoint);
 

--- a/js/speed_test.js
+++ b/js/speed_test.js
@@ -157,6 +157,7 @@ async function runTest() {
   testInProgress = true;
   pendingRun = false;
   startTime = Date.now();
+  lastSavedTime = startTime;
   prevBytes = totalBytes = 0;
   lastSavedBytes = 0;
   consecutiveErrors = 0;


### PR DESCRIPTION
## Summary
- Track last data point save time globally
- Reset last-saved timer at test start
- Compute elapsed time between saved points and update timer after each save

## Testing
- `node --check js/config.js`
- `node --check js/speed_test.js`
- `node --check js/data_point.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cdb2065648329a517767f55828c41