### PR TITLE
Show full speed camera info in marker popup

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -271,9 +271,13 @@ function updateSpeedCameraLayer() {
                             const lon = item["Довгота"];
                             if (lat == null || lon == null) return null;
                             const marker = L.marker([lat, lon]);
-                            if (item["Адреса"]) {
-                                marker.bindPopup(item["Адреса"]);
-                            }
+
+                            const popupContent = Object.entries(item)
+                                .map(([key, value]) =>
+                                    `<div><strong>${ensureColon(key)}</strong> ${value ?? ''}</div>`
+                                )
+                                .join('');
+                            marker.bindPopup(popupContent);
                             return marker;
                         })
                         .filter(Boolean);


### PR DESCRIPTION
## Summary
- display all speed camera metadata in marker popups using ensureColon formatting

## Testing
- `node --check js/map.js`


------
https://chatgpt.com/codex/tasks/task_e_689cdad361ec8329a6c9350f9412007a