### PR TITLE
Add speed camera proximity voice alerts

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
   <script defer src="js/change_announcer.js"></script>
   <script defer src="js/hromada_change_announcer.js"></script>
   <script defer src="js/road_change_announcer.js"></script>
+  <script defer src="js/speed_camera_announcer.js"></script>
   <script defer src="js/update_GPS_info.js"></script>
   <script defer src="js/point_distance.js"></script>
   <script defer src="js/GPS.js"></script>
@@ -153,6 +154,15 @@
         </div>
       </div>
       <h4 class="mb-10" data-i18n="">Озвучувати</h4>
+      <div class="setting-group">
+        <div class="checkbox-group">
+          <input type="checkbox" id="voiceSpeedCameraApproach" />
+          <label class="setting-label" for="voiceSpeedCameraApproach"
+                 data-i18n="voiceSpeedCameraApproachLabel">
+            Наближення до камери контролю швидкості
+          </label>
+        </div>
+      </div>
 
       <h4 class="mb-10" data-i18n="mapLayersTitle">Відображати на карті</h4>
       <div class="setting-group">

--- a/js/config.js
+++ b/js/config.js
@@ -108,6 +108,7 @@ let settings = {
     voiceAlerts: false,
     voiceHromadaChange: false,
     voiceRoadChange: false,
+    voiceSpeedCameraApproach: false,
     showHromady: false,
     showInternationalRoads: false,
     showNationalRoads: false,

--- a/js/settings.js
+++ b/js/settings.js
@@ -38,6 +38,7 @@ function saveSettings() {
     const voiceAlerts = panel.querySelector("#voiceAlerts");
     const voiceHromadaChange = panel.querySelector("#voiceHromadaChange");
     const voiceRoadChange = panel.querySelector("#voiceRoadChange");
+    const voiceSpeedCameraApproach = panel.querySelector("#voiceSpeedCameraApproach");
     const showHromady = panel.querySelector("#showHromady");
     const showInternationalRoads = panel.querySelector("#showInternationalRoads");
     const showNationalRoads = panel.querySelector("#showNationalRoads");
@@ -50,6 +51,7 @@ function saveSettings() {
     if (voiceAlerts) settings.voiceAlerts = voiceAlerts.checked; else console.warn("voiceAlerts element not found");
     if (voiceHromadaChange) settings.voiceHromadaChange = voiceHromadaChange.checked; else console.warn("voiceHromadaChange element not found");
     if (voiceRoadChange) settings.voiceRoadChange = voiceRoadChange.checked; else console.warn("voiceRoadChange element not found");
+    if (voiceSpeedCameraApproach) settings.voiceSpeedCameraApproach = voiceSpeedCameraApproach.checked; else console.warn("voiceSpeedCameraApproach element not found");
     if (showHromady) settings.showHromady = showHromady.checked; else console.warn("showHromady element not found");
     if (showInternationalRoads) settings.showInternationalRoads = showInternationalRoads.checked; else console.warn("showInternationalRoads element not found");
     if (showNationalRoads) settings.showNationalRoads = showNationalRoads.checked; else console.warn("showNationalRoads element not found");
@@ -91,6 +93,7 @@ function loadSettings() {
     const voiceAlerts = panel.querySelector("#voiceAlerts");
     const voiceHromadaChange = panel.querySelector("#voiceHromadaChange");
     const voiceRoadChange = panel.querySelector("#voiceRoadChange");
+    const voiceSpeedCameraApproach = panel.querySelector("#voiceSpeedCameraApproach");
     const showHromady = panel.querySelector("#showHromady");
     const showInternationalRoads = panel.querySelector("#showInternationalRoads");
     const showNationalRoads = panel.querySelector("#showNationalRoads");
@@ -103,6 +106,7 @@ function loadSettings() {
     if (voiceAlerts) voiceAlerts.checked = settings.voiceAlerts; else console.warn("voiceAlerts element not found");
     if (voiceHromadaChange) voiceHromadaChange.checked = settings.voiceHromadaChange; else console.warn("voiceHromadaChange element not found");
     if (voiceRoadChange) voiceRoadChange.checked = settings.voiceRoadChange; else console.warn("voiceRoadChange element not found");
+    if (voiceSpeedCameraApproach) voiceSpeedCameraApproach.checked = settings.voiceSpeedCameraApproach; else console.warn("voiceSpeedCameraApproach element not found");
     if (showHromady) showHromady.checked = settings.showHromady; else console.warn("showHromady element not found");
     if (showInternationalRoads) showInternationalRoads.checked = settings.showInternationalRoads; else console.warn("showInternationalRoads element not found");
     if (showNationalRoads) showNationalRoads.checked = settings.showNationalRoads; else console.warn("showNationalRoads element not found");

--- a/js/speed_camera_announcer.js
+++ b/js/speed_camera_announcer.js
@@ -1,0 +1,70 @@
+// js/speed_camera_announcer.js
+
+let speedCameras = null;
+let lastCamera = null;
+let lastDistance = Infinity;
+
+async function loadSpeedCameras() {
+    if (speedCameras) return;
+    const resp = await fetch(SPEED_CAMERA_FILE);
+    speedCameras = await resp.json();
+}
+
+async function checkSpeedCameraProximity() {
+    if (!settings.voiceSpeedCameraApproach) return;
+    if (
+        !Number.isFinite(currentGPSData.latitude) ||
+        !Number.isFinite(currentGPSData.longitude)
+    ) {
+        return;
+    }
+
+    if (!speedCameras) {
+        try {
+            await loadSpeedCameras();
+        } catch (e) {
+            console.error('Failed to load speed cameras', e);
+            return;
+        }
+    }
+
+    let nearest = null;
+    let minDist = Infinity;
+
+    for (const camera of speedCameras) {
+        const dist = calculateDistance(
+            currentGPSData.latitude,
+            currentGPSData.longitude,
+            camera["Широта"],
+            camera["Довгота"]
+        );
+        if (dist < minDist) {
+            minDist = dist;
+            nearest = camera;
+        }
+    }
+
+    if (!nearest) return;
+
+    if (lastCamera !== nearest) {
+        lastCamera = nearest;
+        lastDistance = minDist;
+        return;
+    }
+
+    if (minDist < lastDistance) {
+        for (const threshold of [1000, 500, 100]) {
+            if (lastDistance > threshold && minDist <= threshold) {
+                speak(
+                    `Через ${Math.round(minDist)} метрів обмеження швидкості у ${nearest["Максимальна швидкість"]}`
+                );
+                break;
+            }
+        }
+    }
+
+    lastDistance = minDist;
+}
+
+window.checkSpeedCameraProximity = checkSpeedCameraProximity;
+

--- a/js/update_GPS_info.js
+++ b/js/update_GPS_info.js
@@ -113,6 +113,7 @@ function updateGPSInfo() {
 
     void updateAdminInfo().catch(console.error);
     void updateRoadInfo().catch(console.error);
+    void checkSpeedCameraProximity().catch(console.error);
 }
 
 async function updateAdminInfo() {

--- a/translations/en.js
+++ b/translations/en.js
@@ -17,6 +17,7 @@ window.i18n.en = {
   voiceChangeTitle: "Voice change",
   voiceHromadaChangeLabel: "Community",
   voiceRoadChangeLabel: "Road",
+  voiceSpeedCameraApproachLabel: "Approaching speed camera",
   mapLayersTitle: "Display on the map",
   showHromadyLabel: "Community boundaries",
   showInternationalRoadsLabel: "International roads",

--- a/translations/uk.js
+++ b/translations/uk.js
@@ -17,6 +17,7 @@ window.i18n.uk = {
   voiceChangeTitle: "Озвучувати зміну",
   voiceHromadaChangeLabel: "Громади",
   voiceRoadChangeLabel: "Дороги",
+  voiceSpeedCameraApproachLabel: "Наближення до камери контролю швидкості",
   mapLayersTitle: "Відображати на карті",
   showHromadyLabel: "Межі громад",
   showInternationalRoadsLabel: "Міжнародні дороги",


### PR DESCRIPTION
## Summary
- add voice setting for approaching speed cameras and load announcer script
- store and restore voiceSpeedCameraApproach setting
- implement speed camera proximity announcer and trigger during GPS updates

## Testing
- `node --check js/speed_camera_announcer.js`
- `node --check js/settings.js`
- `node --check js/update_GPS_info.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cdfca9c608329ae73bf4040a75fd5