### PR TITLE
Add optional percent display for speed counts

### DIFF
--- a/js/update_speed_distribution.js
+++ b/js/update_speed_distribution.js
@@ -20,15 +20,19 @@ function updateSpeedDistribution() {
     }
 
     const total = stats.total;
-    const setCount = (id, count) => {
+    const setCount = (id, count, showPercent = true) => {
         const el = document.getElementById(id);
         if (el) {
-            const percent = total ? Math.round((count / total) * 100) : 0;
-            el.textContent = `${count} (${percent}%)`;
+            if (showPercent) {
+                const percent = total ? Math.round((count / total) * 100) : 0;
+                el.textContent = `${count} (${percent}%)`;
+            } else {
+                el.textContent = `${count}`;
+            }
         }
     };
 
-    setCount("allSpeedCount", stats.total);
+    setCount("allSpeedCount", stats.total, false);
     setCount("zeroSpeedCount", stats.zero);
     setCount("upto2SpeedCount", stats.upto2);
     setCount("above2SpeedCount", stats.above2);


### PR DESCRIPTION
## Summary
- allow `setCount` to hide percentage display
- show raw total count without percent in speed distribution table

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d81ad4b708329bc9c9a6a08341ccc