### PR TITLE
Handle multiple speed camera thresholds

### DIFF
--- a/js/speed_camera_announcer.js
+++ b/js/speed_camera_announcer.js
@@ -53,10 +53,9 @@ async function checkSpeedCameraProximity() {
     }
 
     if (minDist < lastDistance) {
-        for (const threshold of [1000, 500, 100]) {
+        for (const threshold of [100, 500, 1000]) {
             if (lastDistance > threshold && minDist <= threshold) {
                 speak(`Через ${Math.round(minDist)} метрів обмеження швидкості у ${nearest["Максимальна швидкість"]} кілометрів на годину`);
-                break;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Sort speed camera approach thresholds in ascending order
- Allow multiple proximity warnings by removing loop break

## Testing
- `node --check js/speed_camera_announcer.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d8f8be5208329a2ac24e4eda04099