### PR TITLE
Show speed camera circles

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -265,12 +265,18 @@ function updateSpeedCameraLayer() {
             fetch(SPEED_CAMERA_FILE)
                 .then(r => r.json())
                 .then(data => {
-                    const markers = data
+                    const layers = data
                         .map(item => {
                             const lat = item["Широта"];
                             const lon = item["Довгота"];
                             if (lat == null || lon == null) return null;
                             const marker = L.marker([lat, lon]);
+                            const circle = L.circle([lat, lon], {
+                                color: 'red',
+                                fillColor: 'red',
+                                fillOpacity: 0.5,
+                                radius: 100,
+                            });
 
                             const popupContent = Object.entries(item)
                                 .map(([key, value]) =>
@@ -278,10 +284,10 @@ function updateSpeedCameraLayer() {
                                 )
                                 .join('');
                             marker.bindPopup(popupContent);
-                            return marker;
+                            return L.layerGroup([circle, marker]);
                         })
                         .filter(Boolean);
-                    speedCameraLayer = L.layerGroup(markers).addTo(map);
+                    speedCameraLayer = L.layerGroup(layers).addTo(map);
                 })
                 .catch(err => console.error('Speed camera load failed', err));
         }


### PR DESCRIPTION
## Summary
- Add red circle overlay around each speed camera marker.
- Group circles and markers so speed camera layer shows both.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689da2eff958832980c75623b2b39981