### PR TITLE
feat: add warning ring to speed camera markers

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -270,11 +270,17 @@ function updateSpeedCameraLayer() {
                             const lat = item["Широта"];
                             const lon = item["Довгота"];
                             if (lat == null || lon == null) return null;
-                            const circle = L.circle([lat, lon], {
+                            const innerCircle = L.circle([lat, lon], {
                                 color: 'red',
                                 fillColor: 'red',
                                 fillOpacity: 0.5,
                                 radius: 100,
+                            });
+                            const outerCircle = L.circle([lat, lon], {
+                                color: 'yellow',
+                                fillColor: 'yellow',
+                                fillOpacity: 0.1,
+                                radius: 500,
                             });
 
                             const popupContent = Object.entries(item)
@@ -282,8 +288,9 @@ function updateSpeedCameraLayer() {
                                     `<div><strong>${ensureColon(key)}</strong> ${value ?? ''}</div>`
                                 )
                                 .join('');
-                            circle.bindPopup(popupContent);
-                            return circle;
+
+                            const group = L.layerGroup([innerCircle, outerCircle]).bindPopup(popupContent);
+                            return group;
                         })
                         .filter(Boolean);
                     speedCameraLayer = L.layerGroup(layers).addTo(map);


### PR DESCRIPTION
## Summary
- add yellow outer circle around speed camera markers
- group inner and outer circles so popup works for the whole marker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689db6b092d88329b298e3ed8c568dd8