### PR TITLE
Bind popups individually for speed camera circles

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -289,7 +289,9 @@ function updateSpeedCameraLayer() {
                                 )
                                 .join('');
 
-                            const group = L.layerGroup([innerCircle, outerCircle]).bindPopup(popupContent);
+                            innerCircle.bindPopup(popupContent);
+                            outerCircle.bindPopup(popupContent);
+                            const group = L.layerGroup([innerCircle, outerCircle]);
                             return group;
                         })
                         .filter(Boolean);


### PR DESCRIPTION
## Summary
- Bind speed camera popups to both inner and outer circles, allowing info windows on either shape

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dcce911c083298b05c6eae6098518