### PR TITLE
Reset speed when connection drops

### DIFF
--- a/js/speed_test.js
+++ b/js/speed_test.js
@@ -28,6 +28,7 @@ async function resetTestState() {
         alertIndicatorEl.style.display = "block";
     }
     speedValueEl.textContent = "0.00";
+    currentSpeedMbps = 0;
 }
 
 function updateSpeedPerSecond(bytes, elapsedMs) {
@@ -187,6 +188,7 @@ async function runTest() {
       }
       isConnected = false;
       consecutiveErrors++;
+      currentSpeedMbps = 0;
       document.getElementById("speedValue").textContent = "0.00";
       document.getElementById("status").textContent = t('statusNoConnection', 'Відсутнє з\'єднання');
       document.getElementById("alertIndicator").style.display = "block";

--- a/js/update_UI.js
+++ b/js/update_UI.js
@@ -38,6 +38,9 @@ function updateUI() {
 
         // Ховаємо індикатор помилки
         alertIndicatorEl.style.display = "none";
+    } else {
+        currentSpeedMbps = 0;
+        speedValueEl.textContent = "0.00";
     }
 
     downloadedValueEl.textContent = formatDownloaded(totalBytes);


### PR DESCRIPTION
## Summary
- Reset current speed variable when resetting test state or handling connection errors
- Keep UI speed synchronized at zero when not connected

## Testing
- `node --check js/speed_test.js`
- `node --check js/update_UI.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0080dea588329a338ec16420eadcd