### PR TITLE
Delay cleanup of download link

### DIFF
--- a/js/file_download.js
+++ b/js/file_download.js
@@ -5,6 +5,10 @@ function saveBlob(blob, fileName) {
     link.style.display = 'none';
     document.body.appendChild(link);
     link.click();
-    URL.revokeObjectURL(link.href);
-    document.body.removeChild(link);
+    // Delay cleanup to prevent large file downloads from failing if the URL
+    // is revoked before the download fully starts.
+    setTimeout(() => {
+        URL.revokeObjectURL(link.href);
+        document.body.removeChild(link);
+    }, 0);
 }


### PR DESCRIPTION
## Summary
- Wrap download link cleanup in a short timeout to avoid premature `ObjectURL` revocation for large files.
- Explain the need for the delay in a code comment.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4cc21378832994842b3517c6f535